### PR TITLE
Fix ParserComb example

### DIFF
--- a/doc/src/smlnj-lib/README.md
+++ b/doc/src/smlnj-lib/README.md
@@ -1,6 +1,6 @@
 This directory tree contains documentation for the
 various libraries that comprise the **Standard ML of
-Ney Jersey Library**.  The documentation is written
+New Jersey Library**.  The documentation is written
 using [AscciDoctor](https://asciidoctor.org).
 
 ## Naming conventions

--- a/doc/src/smlnj-lib/src/Util/str-ParserComb.adoc
+++ b/doc/src/smlnj-lib/src/Util/str-ParserComb.adoc
@@ -199,9 +199,10 @@ We can then define parsers for the atomic expressions
 [source,sml]
 ------------
 fun numParser getc = P.wrap (Int.scan StringCvt.DEC, NUM) getc
-fun idParser getc = P.seqWith String.^ (
-      P.wrap (P.eatChar Char.isAlpha, str),
-      P.token Char.isAlphaNum) getc
+fun idParser getc =
+      P.seqWith (fn (a, SOME b) => a ^ b | (a, NONE) => a) (
+        P.wrap (P.eatChar Char.isAlpha, str),
+        P.option (P.token Char.isAlphaNum)) getc
 fun varParser getc = P.wrap(idParser, VAR) getc
 ------------
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
The example in the ParserComb documentation did not return the expected result because idParser did not support single-character identifiers. This commit fixes it.

## Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
n/a

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Bug fix.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
- I ran the example and confirmed that it produced the expected result.
- I built the documentation HTML pages and checked that it rendered correctly.