### PR TITLE
Reworked the `UTF8` structure to address issue #276 (`UTF8.getu` should validate that it's input is UTF-8).

### DIFF
--- a/doc/src/smlnj-lib/src/Util/str-UTF8.adoc
+++ b/doc/src/smlnj-lib/src/Util/str-UTF8.adoc
@@ -21,6 +21,16 @@ The encoding scheme uses one to four bytes as follows:
 | `wwwzz` `zzzzyyyy` `yyxxxxxx` | `11110www` | `10zzzzzz` | `10yyyyyy` | `10xxxxxx`
 |===
 
+There are three additional well-formedness restrictions on UTF-8 encodings
+that were introduced in the Unicode 3.1 and 3.2 standards.
+--
+* Characters cannot be larger than `0x10FFFF` (the maximum code point).
+* Characters must be in the **shortest** encoding for the codepoint (_e.g._,
+  using two bytes to encode an ASCII character is invalid).
+* Surogate pairs should be encoded as a single three-byte character instead of
+  as two three-byte sequences.
+--
+
 == Synopsis
 
 [source,sml]
@@ -38,6 +48,7 @@ type wchar = word
 val maxCodePoint : wchar
 
 exception Incomplete
+exception Invalid
 
 val getu : (char, 'strm) StringCvt.reader -> (wchar, 'strm) StringCvt.reader
 
@@ -50,6 +61,8 @@ val fromAscii : char -> wchar
 val toString : wchar -> string
 
 val size : string -> int
+
+val size' : substring -> int
 
 val explode : string -> wchar list
 val implode : wchar list -> string
@@ -75,18 +88,25 @@ val exists : (wchar -> bool) -> string -> bool
 [[exn:Incomplete]]
 `[.kw]#exception# Incomplete`::
   This exception is raised when certain operations are applied to incomplete
-  strings (_i.e._, strings that end with a partial *UTF-8* character encoding).
+  strings (_i.e._, strings that end in the middle of multi-byte *UTF-8* character
+  encoding).
+
+[[exn:Invalid]]
+`[.kw]#exception# Invalid`::
+  This exception is raised when invalid UTF-8 encodings, such as
+  non-shortest-length encodings, are encountered.
 
 `[.kw]#val# getu : (char, 'strm) {sml-basis-url}/string-cvt.html#SIG:STRING_CVT.reader:TY[StringCvt.reader] \-> (wchar, 'strm) {sml-basis-url}/string-cvt.html#SIG:STRING_CVT.reader:TY[StringCvt.reader]`::
   `getu getc` returns a wide-character reader for the character reader `getc`.
-  The resulting reader will raise the xref:#exn:Incomplete[`Incomplete`] exception
-  if it encounters an incomplete *UTF-8* character.
+  The resulting reader raises the xref:#exn:Incomplete[`Incomplete`] exception
+  if it encounters an incomplete *UTF-8* character and it raises the
+  xref:#exn:Invalid[`Invalid`] exception if it encounters an invalid encoding.
 
 `[.kw]#val# encode : wchar \-> string`::
   `encode wc` returns the *UTF-8* encoding of the wide character `wc`.
   This expression raises the
-  {sml-basis-url}/general.html#SIG:GENERAL.Domain:EXN[`Domain`] exception
-  if `wc` is greater than the maximum *Unicode* code point.
+  xref:#exn:Invalid[`Invalid`] exception if `wc` is greater than the
+  maximum *Unicode* code point.
 
 `[.kw]#val# isAscii : wchar \-> bool`::
   `isAscii wc` returns `true` if, and only if, `wc` is an ASCII character.
@@ -109,6 +129,20 @@ val exists : (wchar -> bool) -> string -> bool
   xref:#exn:Incomplete[`Incomplete`] exception if an incomplete
   character is encountered.
 
+`[.kw]#val# size : string \-> int`::
+  `size s` returns the number of *UTF-8* encoded *Unicode* characters
+  in the string `s`.  This expression raises the
+  xref:#exn:Incomplete[`Incomplete`] exception
+  if it encounters an incomplete *UTF-8* character and it raises the
+  xref:#exn:Invalid[`Invalid`] exception if it encounters an invalid encoding.
+
+`[.kw]#val# size' : substring \-> int`::
+  `size' ss` returns the number of *UTF-8* encoded *Unicode* characters
+  in the substring `ss`.  This expression raises the
+  xref:#exn:Incomplete[`Incomplete`] exception
+  if it encounters an incomplete *UTF-8* character and it raises the
+  xref:#exn:Invalid[`Invalid`] exception if it encounters an invalid encoding.
+
 `[.kw]#val# explode : string \-> wchar list`::
   `explode s` returns the list of *UTF-8* encoded Unicode characters that
   comprise the string `s`.
@@ -117,16 +151,14 @@ val exists : (wchar -> bool) -> string -> bool
   `implode wcs` returns the *UTF-8* encoded string that represents
   the list `wcs` of Unicode code points.
   This expression raises the
-  {sml-basis-url}/general.html#SIG:GENERAL.Domain:EXN[`Domain`] exception
-  if any character in the list is greater than the maximum *Unicode* code point.
+  xref:#exn:Invalid[`Invalid`] exception if it encounters an invalid encoding.
 
 `[.kw]#val# map : (wchar \-> wchar) \-> string \-> string`::
   `map f s` maps the function `f` over the *UTF-8* encoded characters
   in the string `s` to produce a new *UTF-8* string. This expression raises
-  the xref:#exn:Incomplete[`Incomplete`] exception if an incomplete
-  character is encountered and the
-  {sml-basis-url}/general.html#SIG:GENERAL.Domain:EXN[`Domain`] exception
-  if `f` returns a value that is greater than the maximum *Unicode* code point.
+  the xref:#exn:Incomplete[`Incomplete`] exception
+  if it encounters an incomplete *UTF-8* character and it raises the
+  xref:#exn:Invalid[`Invalid`] exception if it encounters an invalid encoding.
   It is equivalent to the expression
 +
 [source,sml]
@@ -137,8 +169,10 @@ implode (List.map f (explode s))
 `[.kw]#val# app : (wchar \-> unit) \-> string \-> unit`::
   `app f s` applies the function `f` to the  *UTF-8* encoded characters
   in the string `s`.  This expression raises the
-  xref:#exn:Incomplete[`Incomplete`] exception if an incomplete
-  character is encountered.  It is equivalent to the expression
+  xref:#exn:Incomplete[`Incomplete`] exception
+  if it encounters an incomplete *UTF-8* character and it raises the
+  xref:#exn:Invalid[`Invalid`] exception if it encounters an invalid encoding.
+  It is equivalent to the expression
 +
 [source,sml]
 ------------
@@ -147,9 +181,10 @@ List.app f (explode s)
 
 `[.kw]#val# fold : ((wchar * 'a) \-> 'a) \-> 'a \-> string \-> 'a`::
   `fold f init s` folds a function from left-to-right over the
-  *UTF-8* encoded characters in the string.  This expression raises
-  the xref:#exn:Incomplete[`Incomplete`] exception if an incomplete
-  character is encountered.  It is equivalent to the expression
+  *UTF-8* encoded characters in the string.  xref:#exn:Incomplete[`Incomplete`] exception
+  if it encounters an incomplete *UTF-8* character and it raises the
+  xref:#exn:Invalid[`Invalid`] exception if it encounters an invalid encoding.
+  It is equivalent to the expression
 +
 [source,sml]
 ------------
@@ -161,8 +196,10 @@ List.foldl f init (explode s)
   returns true for all of the *UTF-8* encoded characters in the
   string.  It short-circuits evaluation as soon as a character
   is encountered for which `pred` returns `false`.  This expression
-  raises the xref:#exn:Incomplete[`Incomplete`] exception if an incomplete
-  character is encountered.  It is equivalent to the expression
+  raises the xref:#exn:Incomplete[`Incomplete`] exception
+  if it encounters an incomplete *UTF-8* character and it raises the
+  xref:#exn:Invalid[`Invalid`] exception if it encounters an invalid encoding.
+  It is equivalent to the expression
 +
 [source,sml]
 ------------
@@ -176,8 +213,10 @@ when `s` only contains complete characters.
   returns `true` for at least one *UTF-8* encoded character in
   the string `s`.  It short-circuits evaluation as soon as a character
   is encountered for which `pred` returns `true`.  This expression raises
-  the xref:#exn:Incomplete[`Incomplete`] exception if an incomplete
-  character is encountered.  It is equivalent to the expression
+  the xref:#exn:Incomplete[`Incomplete`] exception
+  if it encounters an incomplete *UTF-8* character and it raises the
+  xref:#exn:Invalid[`Invalid`] exception if it encounters an invalid encoding.
+  It is equivalent to the expression
 +
 [source,sml]
 ------------

--- a/smlnj-lib/CHANGES
+++ b/smlnj-lib/CHANGES
@@ -5,6 +5,14 @@ correspond to SML/NJ releases.
 Next Release
 -------------------
 
+[2023-11-04]
+        Reworked the `UTF8` structure to impose stricter validation of the
+        encodings.  Added the `Invalid` exception for when an invalid encoding
+        is encountered and replaced uses of the `Domain` exception with `Invalid`.
+        Also added the `size'` function for getting the number of UTF-8
+        characters in a substring.  These changes address GitHub issue 276
+        (`UTF8.getu` should validate that it's input is UTF-8).
+
 [2023-09-19]
 	Added modules for the representation of booleans, integers, and words
 	as hash-consed values to the HashCons library.

--- a/smlnj-lib/Util/utf8-sig.sml
+++ b/smlnj-lib/Util/utf8-sig.sml
@@ -13,28 +13,46 @@ signature UTF8 =
 
     val maxCodePoint : wchar	(* = 0wx0010FFFF *)
 
+    (* raised by some operations when applied to incomplete strings. *)
     exception Incomplete
-	(* raised by some operations when applied to incomplete strings. *)
+
+    (* raised when invalid Unicode/UTF8 characters are encountered in certain
+     * situations.
+     *)
+    exception Invalid
 
   (** Character operations **)
 
+    (* convert a character reader to a wide-character reader; the reader
+     * raises `Incomplete` when the end of input is encountered in the middle
+     * of a multi-byte encoding and `Invalid` when an invalid UTF8 encoding
+     * is encountered.
+     *)
     val getu : (char, 'strm) StringCvt.reader -> (wchar, 'strm) StringCvt.reader
-	(* convert a character reader to a wide-character reader *)
 
+    (* return the UTF8 encoding of a wide character; raises Invalid if the
+     * wide character is larger than the maxCodePoint, but does not do any
+     * other validity checking.
+     *)
     val encode : wchar -> string
-	(* return the UTF8 encoding of a wide character *)
 
     val isAscii : wchar -> bool
     val toAscii : wchar -> char		(* truncates to 7-bits *)
     val fromAscii : char -> wchar	(* truncates to 7-bits *)
 
+    (* return a printable string representation of a wide character; raises
+     * Invalid if the wide character is larger than the maxCodePoint, but
+     * does not do any other validity checking.
+     *)
     val toString : wchar -> string
-	(* return a printable string representation of a wide character *)
 
   (** String operations **)
 
     val size : string -> int
-	(* return the number of Unicode characters *)
+	(* return the number of Unicode characters in a string *)
+
+    val size' : substring -> int
+	(* return the number of Unicode characters in a substring *)
 
     val explode : string -> wchar list
 	(* return the list of wide characters that are encoded by a string *)
@@ -53,4 +71,3 @@ signature UTF8 =
     val exists : (wchar -> bool) -> string -> bool
 
   end
-


### PR DESCRIPTION
Added the `Invalid` exception for when an invalid encoding is encountered and replaced uses of the `Domain` exception with `Invalid`.  Also added the `size'` function for getting the number of UTF-8 characters in a substring.
