### PR TITLE
DynamicArray.subArray creates array with length bound+1

### DIFF
--- a/smlnj-lib/Util/dynamic-array-fn.sml
+++ b/smlnj-lib/Util/dynamic-array-fn.sml
@@ -54,9 +54,9 @@ functor DynamicArrayFn (A : MONO_ARRAY) : MONO_DYNAMIC_ARRAY =
           fun copy i = A.sub(arrval, i+lo)
           in
             if hi <= bnd
-              then BLOCK(ref(A.tabulate(hi-lo, copy)), dflt, ref(hi-lo))
+              then BLOCK(ref(A.tabulate(hi-lo+1, copy)), dflt, ref(hi-lo))
             else if lo <= bnd
-              then BLOCK(ref(A.tabulate(bnd-lo, copy)), dflt, ref(bnd-lo))
+              then BLOCK(ref(A.tabulate(bnd-lo+1, copy)), dflt, ref(bnd-lo))
             else
               array(0,dflt)
           end
@@ -100,7 +100,7 @@ functor DynamicArrayFn (A : MONO_ARRAY) : MONO_DYNAMIC_ARRAY =
               in
                 (bndref := !bnd'; arr := !arr')
               end
-            else fillDflt(bnd,newbnd)
+            else (bndref := newbnd; fillDflt(bnd,newbnd))
           end
 
   end (* DynamicArrayFn *)

--- a/smlnj-lib/Util/dynamic-array.sml
+++ b/smlnj-lib/Util/dynamic-array.sml
@@ -62,9 +62,9 @@ structure DynamicArray :> DYNAMIC_ARRAY =
           fun copy i = A.sub(arrval, i+lo)
           in
             if hi <= bnd
-              then BLOCK(ref(A.tabulate(hi-lo, copy)), dflt, ref(hi-lo))
+              then BLOCK(ref(A.tabulate(hi-lo+1, copy)), dflt, ref(hi-lo))
             else if lo <= bnd
-              then BLOCK(ref(A.tabulate(bnd-lo, copy)), dflt, ref(bnd-lo))
+              then BLOCK(ref(A.tabulate(bnd-lo+1, copy)), dflt, ref(bnd-lo))
             else
               array(0, dflt)
           end
@@ -108,7 +108,7 @@ structure DynamicArray :> DYNAMIC_ARRAY =
               in
                 (bndref := !bnd'; arr := !arr')
               end
-            else fillDflt(bnd, newbnd)
+            else (bndref := newbnd; fillDflt(bnd, newbnd))
           end
 
   (* get the array slice that covers the defined portion of the array *)


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->

Running this in the REPL:

```sml
val arr = DynamicArray.array (10, 0)
val () = DynamicArray.update (arr, 0, 1)
val () = DynamicArray.update (arr, 1, 1)
val () = DynamicArray.update (arr, 2, 1)
val subarr = DynamicArray.toList (DynamicArray.subArray (arr, 0, 2))
```

raises a `Subscript` exception, even though the values in the range [0, 2] are set.
Similarly, running this in the REPL:

```sml
val arr = DynamicArray.array (10, 0)
val () = DynamicArray.update (arr, 0, 1)
val () = DynamicArray.update (arr, 1, 1)
val () = DynamicArray.update (arr, 2, 1)
val () = DynamicArray.truncate (arr, 2)
```

will cause `arr` to be in an invalid state, so running `DynamicArray.toList arr` or `DynamicArray.toVector arr` will raise a `Subscript` exception.

This is because `subArray` creates an array with the length of the new array bound, even though the comment in the file says that the array should have at least bound+1 elements.

I also modified `truncate` to set the bound reference even when the array size <= 3 * sz. With this change, `truncate` can be used to consistently lower the bound of the dynamic array.

## Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

I want to use `DynamicArray.truncate` to lower the bound, and I want to use `DynamicArray.bound + 1` as the length of all the set elements in the array. Right now `truncate` often results in an invalid state, and it only lowers the bound in certain cases, which means that the elements from [0, bound] may include zeroed out values.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

I loaded the updated smlnj-lib.cm file into the REPL and ran this:
```
> val arr = DynamicArray.array (10, 0);
val arr = - : int DynamicArray.array
> DynamicArray.update (arr, 0, 1);
val it = (): unit
> DynamicArray.update (arr, 1, 1);
val it = (): unit
> DynamicArray.update (arr, 2, 1);
val it = (): unit
> DynamicArray.toList (DynamicArray.subArray (arr, 0, 2));
val it = [1, 1, 1]: int list

> val arr = DynamicArray.array (10, 0);
val arr = - : int DynamicArray.array
> DynamicArray.update (arr, 0, 1);
val it = (): unit
> DynamicArray.update (arr, 1, 1);
val it = (): unit
> DynamicArray.update (arr, 2, 1);
val it = (): unit
> DynamicArray.truncate (arr, 2);
val it = (): unit
> DynamicArray.truncate (arr, 1);
val it = (): unit
> DynamicArray.truncate (arr, 0);
val it = (): unit

- val arr = DynamicArray.array (3, 0);
val arr = - : int DynamicArray.array
- DynamicArray.update (arr, 0, 1);
val it = () : unit
- DynamicArray.update (arr, 1, 1);
val it = () : unit
- DynamicArray.update (arr, 2, 1);
val it = () : unit
- DynamicArray.bound arr;
val it = 2 : int
- DynamicArray.truncate (arr, 2);
val it = () : unit
- DynamicArray.bound arr;
val it = 1 : int
```
