### PR TITLE
Clarify ORD_SET.isSubset documentation

### DIFF
--- a/doc/src/smlnj-lib/src/Util/sig-ORD_SET.adoc
+++ b/doc/src/smlnj-lib/src/Util/sig-ORD_SET.adoc
@@ -175,7 +175,7 @@ val find : (item -> bool) -> set -> item option
 
 `[.kw]#val# isSubset : (set * set) \-> bool`::
   `isSubset (set1, set2)` returns true if, and only if, `set1`
-  is a subset of `set2` (_i.e._, any element of `set1` is an
+  is a subset of `set2` (_i.e._, every element of `set1` is an
   element of `set2`).
 
 `[.kw]#val# disjoint : set * set \-> bool`::


### PR DESCRIPTION

## Description
In the description of `isSubset` in `ORD_SET`, it mentions that `isSubset (set1, set2) returns true if, and only if, set1 is a subset of set2 (i.e., any element of set1 is an element of set2).`
Subset requires that *every* element of set1 is an element of set2.


## Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

