### PR TITLE
Fix IntBinarySet's comparison operators to be like BinarySetFn

### DIFF
--- a/smlnj-lib/Util/int-binary-set.sml
+++ b/smlnj-lib/Util/int-binary-set.sml
@@ -178,8 +178,8 @@ structure IntBinarySet :> ORD_SET where type Key.ord_key = Int.int =
 
     fun split_gt (E,x) = E
       | split_gt (T{elt=v,left=l,right=r,...},x) =
-          if (x < v) then split_gt(r,x)
-          else if (x > v) then concat3(split_gt(l,x),v,r)
+          if (x > v) then split_gt(r,x)
+          else if (x < v) then concat3(split_gt(l,x),v,r)
           else r
 
     fun min (T{elt=v,left=E,...}) = v


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
In `split_gt`, IntBinarySet's comparison operators are reversed compared to the BinarySetFn's case expression.

## Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

#310 

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
For the function:
```sml
fun foo () =
  let
    val set1 = IntBinarySet.singleton 5356
    val () = print ("Set1: " ^ showSet set1 ^ "\n")
    val set2 = IntBinarySet.fromList [4986, 5360, 5361]
    val () = print ("Set2: " ^ showSet set2 ^ "\n")
    val result = IntBinarySet.union (set1, set2)
  in
    print ("Set: " ^ showSet result ^ "\n")
  end
```
 results in:
```sml
> foo ();
Set1: [5356]
Set2: [4986, 5360, 5361]
Set: [4986, 5356, 4986, 5360, 5361]
val it = (): unit
```

This results in a set with multiple duplicate numbers added in it. Also intersection doesn't work as expected. Since the SML.NET compiler uses `IntBinarySet` for its sets of symbols, the result is that after adding symbols to the set through unions, the same symbol appears 4 to 5 times in the set but does not show up when calling intersection with a set with that symbol. This results in it hanging forever when translating valid programs to MIL.

<!--- If it fixes an open issue, please link to the issue here. -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

This program:
```sml
structure Main =
struct
  val showSet = fn t0 =>
    "["
    ^ String.concatWith ", " (List.map Int.toString (IntBinarySet.listItems t0))
    ^ "]"
  fun foo () =
    let
      val set1 = IntBinarySet.singleton 5356
      val () = print ("Set1: " ^ showSet set1 ^ "\n")
      val set2 = IntBinarySet.fromList [4986, 5360, 5361]
      val () = print ("Set2: " ^ showSet set2 ^ "\n")
      val result = IntBinarySet.union (set1, set2)
      val intersect = IntBinarySet.intersection (result, set2)
    in
      print ("Set: " ^ showSet result ^ "\n");
      print ("Intersection: " ^ showSet intersect ^ "\n")
    end
end
```
results in this afterwards:
```sml
- Main.foo ();
Set1: [5356]
Set2: [4986, 5360, 5361]
Set: [4986, 5356, 5360, 5361]
Intersection: [4986, 5360, 5361]
val it = () : unit
```

SML.NET no longer hangs forever when compiling the raytrace and primes demo programs.

This issue also appears to be in the legacy SML/NJ repository.