### PR TITLE
Canonicalize import order

### DIFF
--- a/compiler/FLINT/trans/translate.sml
+++ b/compiler/FLINT/trans/translate.sml
@@ -352,23 +352,39 @@ fun mergePidInfo (pi, lty, l, nameOp) =
   end (* mergePidInfo *)
 
 (** a map that stores information about external references *)
-val persmap = ref (PersMap.empty : pidInfo PersMap.map)
+val persmap = ref (PersMap.empty : (int * pidInfo) PersMap.map)
+
+(** a counter that is incremented every time it encounters an external
+ * reference, this gives a canonical order for the imports in persmap. *)
+val useOccur = ref 0
+
+(** post-increment a ref cell *)
+fun inc (cell as ref orig) = orig before cell := orig + 1
+
+(** put the import list in canonical order *)
+fun canonImport (imports: (pid * (int * pidInfo)) list) : (pid * pidInfo) list =
+  let fun gt ((_, (o1, _)), (_, (o2, _))) = o1 > o2
+      fun strip (pid, (_, info)) = (pid, info)
+   in map strip (ListMergeSort.sort gt imports)
+  end
 
 (* mkPid : pid * lty * int list * symbol option -> lvar *)
 fun mkPid (pid, lty, l, nameOp) =
     case PersMap.find (!persmap, pid)
       of NONE =>
 	  let val (pinfo, var) = mkPidInfo (lty, l, nameOp)
-	   in persmap := PersMap.insert(!persmap, pid, pinfo);
+              val occur = inc useOccur
+	   in persmap := PersMap.insert(!persmap, pid, (occur, pinfo));
 	      var
 	  end
-       | SOME pinfo =>
+       | SOME (occur, pinfo) =>
 	  let val (newPinfo, var) = mergePidInfo (pinfo, lty, l, nameOp)
 	      fun rmv (key, map) = (* clear the old pinfo for pid *)
 		  let val (newMap, _) = PersMap.remove(map, key)
 		  in newMap
 		  end handle e => map
-	   in persmap := PersMap.insert(rmv (pid, !persmap), pid, newPinfo);
+              val newEntry = (occur, newPinfo)
+	   in persmap := PersMap.insert(rmv (pid, !persmap), pid, newEntry);
 	      var
 	  end
 
@@ -1637,7 +1653,8 @@ val _ = if CompInfo.anyErrors compInfo
 val body = wrapII body
 
 (** wrapping up the body with the imported variables *)
-val (plexp, imports) = wrapPidInfo (body, PersMap.listItemsi (!persmap))
+val (plexp, imports) =
+  wrapPidInfo (body, canonImport (PersMap.listItemsi (!persmap)))
 
 (** type check body (including kind check) **)
 val ltyerrors = if !FLINT_Control.checkPLambda

--- a/doc/src/changelog/HISTORY.txt
+++ b/doc/src/changelog/HISTORY.txt
@@ -103,6 +103,20 @@ Here is an update to the entry
 //====================================================================
 //== Recent updates
 
+//--------------------------------------------------------------------
+[2025/08/05]::
+Changed the way external references are passed during translation to
+PLambda. Previously, the external references are grouped by the PIDs
+of their compilation units, and the units are sorted by the PIDs. As a
+result, the input order is a property of the external module. This
+change sorts the units by the order of their appearances in the source
+code; modules that are referenced earlier are put before those
+referenced later. This makes the input order a property of the code
+itself.
++
+owner:cs.uchicago.edu/~byronzhong[Byron Zhong]
+
+
 //====================================================================
 == Version 2025.2; 2025/07/29
 


### PR DESCRIPTION
This PR changed the way external references are passed during translation to PLambda. Previously, the external references are grouped by the PIDs of their compilation units, and the units are sorted by the PIDs. As a result, the input order is a property of the external module. This change sorts the units by the order of their appearances in the source code; modules that are referenced earlier are put before those referenced later. This makes the input order a property of the code itself.

See issue #319 for a more detailed discussion.

## Related Issue
Fixes #319 

## How Has This Been Tested?
The compiler is able to compile itself and all libraries.
