### PR TITLE
Fix typechecker issues #137, #262, #317

### DIFF
--- a/compiler/ElabData/syntax/absyn.sig
+++ b/compiler/ElabData/syntax/absyn.sig
@@ -83,7 +83,7 @@ signature ABSYN =
       | ORpat of pat * pat
       | VECTORpat of pat list * Types.ty
       | MARKpat of pat * region
-      | NOpat
+      | NOpat (* Error pattern *)
 
     and dec
       = VALdec of vb list

--- a/compiler/ElabData/syntax/ppabsyn.sml
+++ b/compiler/ElabData/syntax/ppabsyn.sml
@@ -193,7 +193,7 @@ fun ppPat env ppstrm =
 	      ppType env ppstrm t;
 	      closeBox ())
           | ppPat' (MARKpat(p,region), d) = ppPat' (p,d)
-	  | ppPat' _ = bug "ppPat'"
+          | ppPat' (NOpat, d) = pps "<error_pat>"
      in ppPat'
     end (* fun ppPat *)
 

--- a/compiler/Elaborator/elaborate/elabcore.sml
+++ b/compiler/Elaborator/elaborate/elabcore.sml
@@ -450,15 +450,15 @@ let
                                 ("constant constructor applied in pattern: "
                                   ^ SP.toString (SP.SPATH path))
                                 EM.nullErrorBody;
-                              (AS.WILDpat, TS.empty))  (* should be NOpat? *)
+                              (AS.NOpat, TS.empty))
                         (* end case *))
                     | AS.VAR _ => ((* constructor path bound to variable *)
                         error region EM.COMPLAIN
                           ("undefined constructor applied in pattern: "
                             ^ SP.toString (SP.SPATH path))
                           EM.nullErrorBody;
-                          (WILDpat, TS.empty))  (* should be NOpat? *)
-                    | AS.ERRORid => (AS.WILDpat, TS.empty)
+                          (AS.NOpat, TS.empty))
+                    | AS.ERRORid => (AS.NOpat, TS.empty)
                         (* lookIdPath will have complained about the unbound path *)
                   (* end case *)
                 end
@@ -468,7 +468,7 @@ let
                 error (getOpt (optRegion, SM.nullRegion)) EM.COMPLAIN
                   "non-constructor applied to argument in pattern"
                   EM.nullErrorBody;
-                (WILDpat, TS.empty)) (* should be NOpat? *)
+                (AS.NOpat, TS.empty))
           in
             getPath (constr, NONE)
           end

--- a/compiler/Elaborator/types/typecheck.sml
+++ b/compiler/Elaborator/types/typecheck.sml
@@ -533,6 +533,7 @@ fun patType(pat: pat, depth, region) : pat * ty =
 		     then (typ := ty; (LAYEREDpat(cpat,npat),MARKty(ty, region)))
 		     else (pat,WILDCARDty)
 		 end)
+       | NOpat => (pat, mkMETAtyBounded depth) (* allow error *)
        | p => bug "patType -- unexpected pattern"
 
 (* expType : exp * OC.occ * region -> exp * ty *)

--- a/doc/src/changelog/HISTORY.txt
+++ b/doc/src/changelog/HISTORY.txt
@@ -104,6 +104,33 @@ Here is an update to the entry
 == Recent updates
 
 //--------------------------------------------------------------------
+[2025/08/11]::
+Reworked type unification. When unifying two types, sometimes the
+types cannot be unified directly, but their head-reduced forms can.
+Because eagerly head-reducing all types can lead to an explosion of
+terms, the legacy branch head-reduces either types when a unification
+error occurs and retries unification. This leads to an exponential
+blowup when type-checking functions with a large number of curried
+arguments. The development branch handles the lazy head-reduction more
+directly, but the previous implementation ignores a few cases where
+the direction of tyvar unifications matters. For example, a UBOUND
+tyvar cannot be instantiated as an OPEN tyvar, but the opposite
+direction works; OVLD tyvars have metadata that needs to be maintained
+for overload resolution to work. This change patches the missing
+cases.
++
+In addition, the NOpat pattern, signaling an elaboration error on a
+pattern, is handled in the typechecker.
++
+This change fixes {issue-base}/137[Issue #137 (Typechecker hangs with
+a large number of curried arguments)], {issue-base}/262[Issue #262
+(Compiler bug in type checker: unexpected pattern)], and
+{issue-base}/317[Issue #317 (Bug in type checking/inference with type
+abbreviations through transparent functor application)].
++
+owner:cs.uchicago.edu/~byronzhong[Byron Zhong]
+
+//--------------------------------------------------------------------
 [2025/08/10]::
 Replaced the pickler for skeleton files in **CM** with one that is
 generated from an **ASDL** specification.  This change is a first step


### PR DESCRIPTION
This PR reworked type unification. When unifying two types, sometimes the types cannot be unified directly, but their head-reduced forms can. Because eagerly head-reducing all types can lead to an explosion of terms, the legacy branch head-reduces either types when a unification error occurs and retries unification. This leads to an exponential blowup when type-checking functions with a large number of curried arguments. The development branch handles the lazy head-reduction more directly, but the previous implementation ignores a few cases where the direction of tyvar unifications matters. For example, a `UBOUND` tyvar cannot be instantiated as an `OPEN` tyvar, but the opposite direction works; `OVLD` tyvars have metadata that needs to be maintained for overload resolution to work. This change patches the missing cases.

In addition, the `NOpat` pattern, signaling an elaboration error on a pattern, is handled in the typechecker.

## Related Issue
* #137 
* #262 
* #317 

## How Has This Been Tested?
The compiler compiles itself and [mlton](https://github.com/MLton/mlton). It passes all [regression tests](https://github.com/smlnj/regression-tests).
