### PR TITLE
setPosOut returns outstream

### DIFF
--- a/libraries/cml/src/IO/bin-io-fn.sml
+++ b/libraries/cml/src/IO/bin-io-fn.sml
@@ -610,7 +610,7 @@ functor BinIOFn (
 	fun setPosOut (OUTP{pos, strm=strmMV}) = let
 	      val (strm as OSTRM{writer, ...}) =
 		    lockAndChkClosedOut (strmMV, "setPosOut")
-	      fun release () = SV.mPut(strmMV, strm)
+	      fun release () = (SV.mPut(strmMV, strm); strmMV)
 	      in
 		case writer
 		 of PIO.WR{setPos=SOME f, ...} => (
@@ -693,7 +693,7 @@ functor BinIOFn (
     fun closeOut strm = StreamIO.closeOut(SV.mGet strm)
     fun getPosOut strm = StreamIO.getPosOut(SV.mGet strm)
     fun setPosOut (strm, p as StreamIO.OUTP{strm=strm', ...}) = (
-	  mUpdate(strm, strm'); StreamIO.setPosOut p)
+	  mUpdate(strm, strm'); ignore (StreamIO.setPosOut p))
 
     fun mkInstream (strm : StreamIO.instream) = SV.mVarInit strm
     fun getInstream (strm : instream) = SV.mGet strm

--- a/libraries/cml/src/IO/bin-io-fn.sml
+++ b/libraries/cml/src/IO/bin-io-fn.sml
@@ -610,7 +610,7 @@ functor BinIOFn (
 	fun setPosOut (OUTP{pos, strm=strmMV}) = let
 	      val (strm as OSTRM{writer, ...}) =
 		    lockAndChkClosedOut (strmMV, "setPosOut")
-	      fun release () = (SV.mPut(strmMV, strm); strmMV)
+	      fun release () = SV.mPut(strmMV, strm)
 	      in
 		case writer
 		 of PIO.WR{setPos=SOME f, ...} => (
@@ -620,7 +620,8 @@ functor BinIOFn (
 		      release();
 		      outputExn(strm, "getPosOut", IO.RandomAccessNotSupported))
 		(* end case *);
-		release()
+		release();
+		strmMV
 	      end
 
 	fun setBufferMode (strmMV, mode) = let

--- a/libraries/cml/src/IO/new-bin-io-fn.sml
+++ b/libraries/cml/src/IO/new-bin-io-fn.sml
@@ -648,7 +648,7 @@ functor BinIOFn (
 	fun setPosOut (OUTP{pos, strm=strmMV}) = let
 	      val (strm as OSTRM{writer, ...}) =
 		    lockAndChkClosedOut (strmMV, "setPosOut")
-	      fun release () = SV.mPut(strmMV, strm)
+	      fun release () = (SV.mPut(strmMV, strm); strmMV)
 	      in
 		case writer
 		 of PIO.WR{setPos=SOME f, ...} => (
@@ -733,7 +733,7 @@ functor BinIOFn (
     fun closeOut strm = StreamIO.closeOut(SV.mGet strm)
     fun getPosOut strm = StreamIO.getPosOut(SV.mGet strm)
     fun setPosOut (strm, p as StreamIO.OUTP{strm=strm', ...}) = (
-	  mUpdate(strm, strm'); StreamIO.setPosOut p)
+	  mUpdate(strm, strm'); ignore (StreamIO.setPosOut p))
 
     fun mkInstream (strm : StreamIO.instream) = SV.mVarInit strm
     fun getInstream (strm : instream) = SV.mGet strm

--- a/libraries/cml/src/IO/new-bin-io-fn.sml
+++ b/libraries/cml/src/IO/new-bin-io-fn.sml
@@ -648,7 +648,7 @@ functor BinIOFn (
 	fun setPosOut (OUTP{pos, strm=strmMV}) = let
 	      val (strm as OSTRM{writer, ...}) =
 		    lockAndChkClosedOut (strmMV, "setPosOut")
-	      fun release () = (SV.mPut(strmMV, strm); strmMV)
+	      fun release () = SV.mPut(strmMV, strm)
 	      in
 		case writer
 		 of PIO.WR{setPos=SOME f, ...} => (
@@ -658,7 +658,8 @@ functor BinIOFn (
 		      release();
 		      outputExn(strm, "getPosOut", IO.RandomAccessNotSupported))
 		(* end case *);
-		release()
+		release();
+		strmMV
 	      end
 
 	fun setBufferMode (strmMV, mode) = let

--- a/libraries/cml/src/IO/new-text-io-fn.sml
+++ b/libraries/cml/src/IO/new-text-io-fn.sml
@@ -755,7 +755,7 @@ functor TextIOFn (
 	fun setPosOut (OUTP{pos, strm=strmMV}) = let
 	      val (strm as OSTRM{writer, ...}) =
 		    lockAndChkClosedOut (strmMV, "setPosOut")
-	      fun release () = (SV.mPut(strmMV, strm); strmMV)
+	      fun release () = SV.mPut(strmMV, strm)
 	      in
 		case writer
 		 of PIO.WR{setPos=SOME f, ...} => (
@@ -765,7 +765,8 @@ functor TextIOFn (
 		      release();
 		      outputExn(strm, "getPosOut", IO.RandomAccessNotSupported))
 		(* end case *);
-		release()
+		release();
+		strmMV
 	      end
 
 	fun setBufferMode (strmMV, mode) = let

--- a/libraries/cml/src/IO/new-text-io-fn.sml
+++ b/libraries/cml/src/IO/new-text-io-fn.sml
@@ -755,7 +755,7 @@ functor TextIOFn (
 	fun setPosOut (OUTP{pos, strm=strmMV}) = let
 	      val (strm as OSTRM{writer, ...}) =
 		    lockAndChkClosedOut (strmMV, "setPosOut")
-	      fun release () = SV.mPut(strmMV, strm)
+	      fun release () = (SV.mPut(strmMV, strm); strmMV)
 	      in
 		case writer
 		 of PIO.WR{setPos=SOME f, ...} => (
@@ -940,7 +940,7 @@ functor TextIOFn (
     fun closeOut strm = StreamIO.closeOut(SV.mGet strm)
     fun getPosOut strm = StreamIO.getPosOut(SV.mGet strm)
     fun setPosOut (strm, p as StreamIO.OUTP{strm=strm', ...}) = (
-	  mUpdate(strm, strm'); StreamIO.setPosOut p)
+	  mUpdate(strm, strm'); ignore (StreamIO.setPosOut p))
 
     fun mkInstream (strm : StreamIO.instream) = SV.mVarInit strm
     fun getInstream (strm : instream) = SV.mGet strm

--- a/libraries/cml/src/IO/text-io-fn.sml
+++ b/libraries/cml/src/IO/text-io-fn.sml
@@ -702,7 +702,7 @@ functor TextIOFn (
 	fun setPosOut (OUTP{pos, strm=strmMV}) = let
 	      val (strm as OSTRM{writer, ...}) =
 		    lockAndChkClosedOut (strmMV, "setPosOut")
-	      fun release () = (SV.mPut(strmMV, strm); strmMV)
+	      fun release () = SV.mPut(strmMV, strm)
 	      in
 		case writer
 		 of PIO.WR{setPos=SOME f, ...} => (
@@ -712,7 +712,8 @@ functor TextIOFn (
 		      release();
 		      outputExn(strm, "getPosOut", IO.RandomAccessNotSupported))
 		(* end case *);
-		release()
+		release();
+		strmMV
 	      end
 
 	fun setBufferMode (strmMV, mode) = let

--- a/libraries/cml/src/IO/text-io-fn.sml
+++ b/libraries/cml/src/IO/text-io-fn.sml
@@ -702,7 +702,7 @@ functor TextIOFn (
 	fun setPosOut (OUTP{pos, strm=strmMV}) = let
 	      val (strm as OSTRM{writer, ...}) =
 		    lockAndChkClosedOut (strmMV, "setPosOut")
-	      fun release () = SV.mPut(strmMV, strm)
+	      fun release () = (SV.mPut(strmMV, strm); strmMV)
 	      in
 		case writer
 		 of PIO.WR{setPos=SOME f, ...} => (
@@ -885,7 +885,7 @@ functor TextIOFn (
     fun closeOut strm = StreamIO.closeOut(SV.mGet strm)
     fun getPosOut strm = StreamIO.getPosOut(SV.mGet strm)
     fun setPosOut (strm, p as StreamIO.OUTP{strm=strm', ...}) = (
-	  mUpdate(strm, strm'); StreamIO.setPosOut p)
+	  mUpdate(strm, strm'); ignore (StreamIO.setPosOut p))
 
     fun mkInstream (strm : StreamIO.instream) = SV.mVarInit strm
     fun getInstream (strm : instream) = SV.mGet strm

--- a/system/Basis/Implementation/IO/bin-io-fn.sml
+++ b/system/Basis/Implementation/IO/bin-io-fn.sml
@@ -545,8 +545,8 @@ functor BinIOFn (
 	       of PIO.WR{setPos=SOME f, ...} => (
 		    (f pos)
 		      handle ex => outputExn(strm, "setPosOut", ex))
-		| _ => outputExn(strm, "getPosOut", IO.RandomAccessNotSupported)
-	      (* end case *))
+		| _ => outputExn(strm, "setPosOut", IO.RandomAccessNotSupported);
+		strm (* end case *))
 
 	fun setBufferMode (strm as OSTRM{bufferMode, ...}, IO.NO_BUF) = (
 	      flushBuffer (strm, "setBufferMode");
@@ -610,7 +610,7 @@ functor BinIOFn (
     fun closeOut strm = StreamIO.closeOut(!strm)
     fun getPosOut strm = StreamIO.getPosOut(!strm)
     fun setPosOut (strm, p as StreamIO.OUTP{strm=strm', ...}) = (
-	  strm := strm'; StreamIO.setPosOut p)
+	  strm := strm'; ignore (StreamIO.setPosOut p))
 
     fun mkInstream (strm : StreamIO.instream) = ref strm
     fun getInstream (strm : instream) = !strm

--- a/system/Basis/Implementation/IO/stream-io.sig
+++ b/system/Basis/Implementation/IO/stream-io.sig
@@ -37,7 +37,7 @@ signature STREAM_IO =
     val mkOutstream   : (writer * IO.buffer_mode) -> outstream
     val getWriter     : outstream -> (writer * IO.buffer_mode)
     val getPosOut     : outstream -> out_pos
-    val setPosOut     : out_pos -> unit
+    val setPosOut     : out_pos -> outstream
     val filePosOut    : out_pos -> pos
 
   end

--- a/system/Basis/Implementation/IO/text-io-fn.sml
+++ b/system/Basis/Implementation/IO/text-io-fn.sml
@@ -648,8 +648,8 @@ functor TextIOFn (
 	       of PIO.WR{setPos=SOME f, ...} => (
 		    (f pos)
 		      handle ex => outputExn(strm, "setPosOut", ex))
-		| _ => outputExn(strm, "getPosOut", IO.RandomAccessNotSupported)
-	      (* end case *))
+		| _ => outputExn(strm, "setPosOut", IO.RandomAccessNotSupported);
+		strm (* end case *))
 
       (** Text stream specific operations **)
 	fun outputSubstr (strm as OSTRM os, ss) = let
@@ -771,7 +771,7 @@ functor TextIOFn (
     fun closeOut strm = StreamIO.closeOut(!strm)
     fun getPosOut strm = StreamIO.getPosOut(!strm)
     fun setPosOut (strm, p as StreamIO.OUTP{strm=strm', ...}) = (
-	  strm := strm'; StreamIO.setPosOut p)
+	  strm := strm'; ignore (StreamIO.setPosOut p))
 
     fun mkInstream (strm : StreamIO.instream) = ref strm
     fun getInstream (strm : instream) = !strm


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
Changes `setPosOut` in `STREAM_IO` to return the outstream passed into it.

## Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
In the Basis library, [STREAM_IO](https://smlfamily.github.io/Basis/stream-io.html)'s function `setPosOut` is of type `out_pos -> outstream` but in SML/NJ it is `out_pos -> unit`. This change will make SML/NJ more compatible with other implementations.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
This doesn't change anything other than returning the outstream, but this code tests that the outstream returned can still be written to:

```sml
structure Main =
struct
  fun main () =
    let
      val outstream = TextIO.getOutstream (TextIO.openOut "hello.txt")
      val outstream =
        TextIO.StreamIO.setPosOut (TextIO.StreamIO.getPosOut outstream)
    in
      TextIO.StreamIO.output (outstream, "hello world\n");
      TextIO.StreamIO.flushOut outstream
    end
end
```
