### PR TITLE
include old PATH in all new PATH redefines

### DIFF
--- a/config/_arch-n-opsys
+++ b/config/_arch-n-opsys
@@ -11,7 +11,7 @@
 #
 
 export PATH
-PATH="/bin:/usr/bin"
+PATH="/bin:/usr/bin:$PATH"
 
 HEAP_OPSYS=""
 case `uname -s` in

--- a/runtime/config/gen-posix-names.sh
+++ b/runtime/config/gen-posix-names.sh
@@ -11,7 +11,7 @@
 
 # redefine PATH so that we get the right versions of the various tools
 #
-PATH=/bin:/usr/bin
+PATH=/bin:/usr/bin:$PATH
 
 # set locale variables so that sort works right
 #


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
this change still makes sure the binaries from /bin and /usr/bin are taken first, but makes the redefinition not fail if they're not found there (e.g. on NixOS, which doesn't store binaries in /bin or /usr/bin)

## Description
<!--- Describe your changes in detail -->

## Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
compiling smlnj on NixOS is not possible without this change

this can be merged without any of my other PRs

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
I compiled the code with these changes as well as the ones mentioned in https://github.com/smlnj/smlnj/pull/331
