### PR TITLE
Add missing `#include <cstdint>` in ASDL

### DIFF
--- a/tools/asdl/src/lib/cpp/include/asdl/asdl-integer.hpp
+++ b/tools/asdl/src/lib/cpp/include/asdl/asdl-integer.hpp
@@ -19,6 +19,8 @@
 #  include <gmp.h>
 #endif
 
+#include <cstdint>
+
 namespace asdl {
 
   // multiprecision integers


### PR DESCRIPTION
For a long time, in `libstdc++`, the header file `<cstdint>` is included in `<iostream>`. Newer versions of GCC no longer do so, causing the header file fail to compile when referring to types such as `uint64_t` in its constructors. The generated code in the LLVM module that uses ASDL also needs to be updated.