### PR TITLE
Fix relocation issues causing MLton crash

### DIFF
--- a/runtime/gc/import-heap.c
+++ b/runtime/gc/import-heap.c
@@ -415,7 +415,7 @@ PVT void ReadHeap (inbuf_t *bp, ml_heap_hdr_t *hdr, ml_state_t *msp, ml_val_t *e
                       /* dump the comment string of the code object */
                         char           *namestring;
                         if ((namestring = (char *)BO_GetCodeObjTag(bdp)) != NIL(char *))
-                            SayDebug ("[%6d bytes] %s\n", bdp->sizeB, namestring);
+                            SayDebug ("[%6d bytes, at %p] %s\n", bdp->sizeB, bdp->obj, namestring);
                     }
                 }
 


### PR DESCRIPTION
#318 is the consequence of the following facts:
- The SimplifyCFG pass in LLVM converts a switch statement to a lookup table when each case of the switch statement only initializes some variables to some constants.
- A defect in the LLVM codegen generates multiple aliases for each code pointer, which are not optimized out by LLVM.
- When a function pointer is in a global table, the global table is put into the .data.rel.ro section, for which the object loader puts the _absolute_ address for each symbol in the section, and then the section is treated as read-only.  On x86-64, the relocation type for each entry is often R_X86_64_64; on ARM64, it is ARM64_RELOC_UNSIGNED.
- The code object is loaded to memory during codegen, and then relocated several times (in and sometimes out of memory) before it is executed.

When the function pointer is retrieved from the lookup table at execution, its address no longer corresponds to any code. Jumping to the address causes a segmentation fault.

The MLton code that causes the crash is https://github.com/MLton/mlton/blob/e44f16ca8cbe1eea16657bf5bd9208f7de158436/mlton/codegen/amd64-codegen/amd64-mlton.fun#L202-L220.

The code can be distilled to the following:
```sml
(* crash.sml *)
local
  fun join (m, n) = (* computation big enough to prevent inlining *)
    (case (Int.sameSign (n, m), Int.sameSign (m, n))
       of (true, true) => (m, n)
        | _ => (m, n))
in
  fun main n =
    let val (a, b) =
          case n
            of 1 => join (2, 5)
             | 2 => join (8, 10)
             | 3 => join (2, 3)
             | 4 => join (6, 2)
             | 5 => join (3, 10)
             | 6 => join (2, 8)
             | 7 => join (8, 2)
             | m => (1, m)
        (* continuation of join *)
        val _ = Int.sameSign (a + b, b)
    in  (b, a)
    end
end
```

```
$ sml crash.sml
Standard ML of New Jersey [Version 2026.1; 64-bit; March 14, 2026]
[opening crash.sml]
val main = fn : int -> int * int
- main 2;
zsh: bus error  sml crash.sml
```

This PR contains @JohnReppy's fix for the codegen defect that generates multiple aliases for the same function pointer, disables SwitchToLookupTable in SimplifyCFG, and minor update that prints the addresses of objects to help debugging.

Fixes #318.

## Detailed Description

Consider the following function in C:
```c
void f1() { printf("f1\n"); }
void f2() { printf("f2\n"); }
void f3() { printf("f3\n"); }
void f4() { printf("f4\n"); }

extern void use(void (*f)());

int main(int argc, char *argv[]) {
    void (*f)();
    switch (argc) {
        case 1:  f = f1; break;
        case 2:  f = f2; break;
        case 3:  f = f3; break;
        default: f = f4; break;
    }
    use(f);
    return 0;
}
```
At the end of its optimization pipeline, LLVM lowers `main` into the following.
```llvm
; clang -S -emit-llvm -fPIC -O2 test.c; cat test.ll
@switch.table.main = private unnamed_addr constant [3 x ptr] [ptr @f1, ptr @f2, ptr @f3], align 8
define noundef i32 @main(i32 noundef %0, ptr nocapture noundef readnone %1) local_unnamed_addr #1 {
  %3 = add i32 %0, -1
  %4 = icmp ult i32 %3, 3
  br i1 %4, label %5, label %9

5:                                                ; preds = %2
  %6 = zext nneg i32 %3 to i64                                                 ; <<<
  %7 = getelementptr inbounds [3 x ptr], ptr @switch.table.main, i64 0, i64 %6 ; <<<
  %8 = load ptr, ptr %7, align 8                                               ; <<<


9:                                                ; preds = %2, %5
  %10 = phi ptr [ %8, %5 ], [ @f4, %2 ]
  tail call void @use(ptr noundef nonnull %10) #4
  ret i32 0
}
```
The table `@switch.table.main` encodes the switch-statement, which lives in the `.data.rel.ro` section in the generated object file. What's important is that relocation type is specified as `R_X86_64_64`, which is a 64-bit absolute address ([x86 ABI](https://refspecs.linuxbase.org/elf/x86_64-abi-0.98.pdf#page=70), p. 69), despite `PIC`.
```
# clang -c -emit-llvm -fPIC -O2 test.c; objdump -r test.o

RELOCATION RECORDS FOR [.data.rel.ro]:
OFFSET           TYPE              VALUE
0000000000000000 R_X86_64_64       f1
0000000000000008 R_X86_64_64       f2
0000000000000010 R_X86_64_64       f3
```


## Notes for Developers

The following steps allow us to create a breakpoint at the ML code.
1. Compile the source code with `-Ccg.dump-cfg=true` to obtain `source.pkl`.
2. Use `cfgc -o source.pkl` to create an object file `source.o`.
3. Use `objdump -d source.o` to find the offset `O` of the instruction of interest.
4. Run the SML/NJ runtime under `lldb` (the runtime is `$(dirname $(which sml))/.run/run.arm64-darwin`) with `@SMLobjects`. The option will print the starting address `S` of each module in memory. 
5. `disassemble (S+O) --count 5` to verify the instruction
6. `breakpoint set --address (S+O)`
