### PR TITLE
Fix missing case in `FLINT/reify`

### DIFF
--- a/compiler/FLINT/reps/typeoper.sml
+++ b/compiler/FLINT/reps/typeoper.sml
@@ -221,7 +221,38 @@ fun tagInt i = INT{ival = IntInf.fromInt i, ty = Target.defaultIntSz}
  *                      TYPED INTERPRETATION OF UNTAGGED                    *
  ****************************************************************************)
 
-(** tc is of kind Omega; this function tests whether tc can be a tagged int ? *)
+(** tc is of kind Omega; this function tests whether tc can be a tagged int ?
+ *    YES: some inhabitants of the type `tc` may be represented as a tagged
+ *      integer. Therefore, when this type is given an UNTAGGED representation
+ *      in a datatype: e.g. datatype t = A | B of tc, where A is represented by
+ *      a constant, and (B x), by box(x). Pattern matching on (a: t) is compiled
+ *      as (see utgd below):
+ *        if boxed(a) then
+ *          a' = unwrap[tuple[tc]](a)
+ *          x  = select a' 0
+ *        else
+ *          ...
+ *    NO: all inhabitants of type `tc` are represented by pointers, so (B x) as
+ *      defined above is represented by identity(x). Pattern matching on (a: T)
+ *      is compiled as follows:
+ *        if boxed(a) then
+ *          x = unwrap[tc](a)
+ *        else
+ *          ...
+ *    MAYBE(runtime_type_code): this cannot be decided statically, so the cases
+ *      are selected based on a runtime type code.
+ *        if boxed(a) then
+ *          x =
+ *            if runtime_type_code = tcode_void then
+ *              .. YES branch ..
+ *            else
+ *              .. NO branch ..
+ *        else
+ *          ..
+ * This function must adhere to the logic of ConRep.infer
+ * (compiler/ElabData/types/conrep.sml).
+ *                                                                         -BZ
+ * *)
 fun tcTag (kenv, tc) =
   let fun loop x =     (* a lot of approximations in this function *)
 	(case (LK.tc_whnm_out x)
@@ -235,7 +266,7 @@ fun tcTag (kenv, tc) =
 	   | (LT.TC_FIX _) => YES
 	   | (LT.TC_APP(tx, _)) =>
 		(case LK.tc_whnm_out tx
-		  of (LT.TC_APP _ | LT.TC_PROJ _ | LT.TC_VAR _) =>
+		  of (LT.TC_APP _ | LT.TC_PROJ _ | LT.TC_VAR _ | LT.TC_NVAR _) =>
 		       MAYBE (tcLexp kenv x)
 		   | _ => YES)
 	   | _ => (MAYBE (tcLexp kenv x)))


### PR DESCRIPTION
To make unboxed values work with polymorphism, FLINT uses a pair of primitives: `wrap[ty](x)`, which converts the actual representation of `x` to a canonical representation of the type `ty`, and `recover[ty](x)`, which is the inverse. When `x`'s type is statically unknown, (e.g., `x`'s type is a type parameter), `x`'s representation is also unknown. In this case, FLINT generates code that passes the type of `x` as a parameter; i.e., the type-functions and type-applications are reified to ordinary functions and applications. `wrap[ty](x)` is then lowered to a runtime test for `x`'s representation followed by the actual representation coercion. See [1] for more details.

The code that determines if `x`'s representation is known statically has a bug. If `x`'s type is a type variable, we don't know the actual representation of `x`, and the runtime type information is needed. But the code that handles this, shown below, only has a case for `LT.TC_VAR`, the de-Bruijn-indexed type variables, but not `LT.TC_NVAR`, the named type variables. After the `deb2name` pass, which occurs before `reify`, all type variables are converted back to named variables. This code wrongly returns that some coercions are not necessary, causing the crashes reported in the issues. 

https://github.com/smlnj/smlnj/blob/1f2c1165996ba2c2f1004a3cc485e6db031775d9/compiler/FLINT/reps/typeoper.sml#L237-L240

This issue can be reproduced at least on smlnj-110.60, which is the oldest version that I can build on my available machines. I suspect that this bug has existed for even longer. 

[1] Shao, Zhong. "Flexible representation analysis." ACM SIGPLAN Notices 32.8 (1997): 85-98.

## Detailed Description

Consider the example in smlnj/legacy#353. 
```sml
functor F(S : sig
  type 'a t
  datatype t' = A | B of int t
end) = struct
  open S
  fun toT (B x) = x | toT A = raise Fail "irrelevant"
end
```
To retrieve the value `x : t` from the `B x` case, we must know how the value is represented. The FLINT IR generated for the functor is the following, simplified for readability:
```txt
 val F118 = 
   tfn [v134:([M]=>M)] =>
     fix v127 (S106: STR[]) =>
       fix toT107 (v113: t') =>
         SWITCH v113
           B => 
               v114 = DECON(B, Untagged, (v134 @[i63]) -> t', v113)
               RETURN [v114]
           A =>
               ... raise ...
```
The functor is split into a type function `tfn [v134]`, where `v134` is the type `t`, and an ordinary function `fix v127`, which takes the value parts of the input structure `S` (which is empty in this case). The `DECON` primitive is supposed to retrieve the value behind the constructor `B`, which is of type `v134 @[i63] -> t'` (`@` denotes a type application), but currently we don't have enough information to implement this primitive.

Different instantiations of the structure `S` will result in different ways of retrieving `x`.
```sml
structure S1 = struct
  type 'a t = 'a * 'a
  datatype t' = A | B of int t
end
```
In this case, since `'a t` must be represented by a pointer, `A` is represented by a tagged-integer constant, and `B x` is represented transparently (i.e., `B x = identity x`)`. The `DECON` for this particular instantiation is the identity. 

```sml
structure S2 = struct
  type 'a t = 'a list
  datatype t' = A | B of int t
end
```
Since `'a t` can either be an integer (the `nil` case) or a pointer (the `cons` case), `B x` must box its argument to ensure that it is distinguishable from `A` (i.e., `B x = box(x)`). The `DECON` in this instance becomes `select (x, 0)`.

The function `tcTag` in `compiler/FLINT/reps/typeoper.sml` analyzes the type `int t` to determine how `DECON` should be implemented. If `int t` cannot possibly be an integer, it lowers `DECON` to the former; otherwise, it lowers `DECON` to the latter. In the case where both are possible, as is the case here, `DECON` implements both following a runtime type test.

The resulting FLINT IR after the bug fix looks the following (simplified for readability).

```
val F118 = 
  fn (v140: { 1={ 1=i63 } -> i63 }) =>
    v134 = SELECT(v140, 0)
    fix v127 (S106: {}) =>
      fix toT107 (v113 : void) =>,
        SWITCH v113
          B => 
              v143 = DECON(B, Untagged, void -> void, v113) (* no-op *)
              v141 = RECORD [(I63)0]
              v146 = APP(v134, [v141])
              IF v146 = 0
              THEN
                  v144 = UNWRAP[void](v143: void)           (* no-op *)
                  v145 = SELECT(v144, 0)
                  RETURN [v145]
              ELSE
                  v147 = UNWRAP[void](v143: void)           (* no-op *)
                  RETURN [v147]
          A =>
              ... raise ...

  ...
```

## Related Issue
Fix smlnj/legacy#353
Fix smlnj/legacy#368

The comment in [#368](https://github.com/smlnj/legacy/issues/368#issuecomment-3114577240) is caused by a separate issue in the `compiler/TopLevel/print/ppobj.sml`, where there is a similar confusion over the representation of `t'`. 

## How Has This Been Tested?
- Both examples in the issues no longer crash.
- The compiler bootstraps successfully.
