### PR TITLE
Mark generated parser and lexer files as generated

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,3 @@
+# https://docs.github.com/en/repositories/working-with-files/managing-files/customizing-how-changed-files-appear-on-github
+*.grm.sml linguist-generated
+*.lex.sml linguist-generated


### PR DESCRIPTION
The `linguist-generated` git attribute is used by
GitHub to aid the diff page.
Diffs in files marked as generated are not displayed by default.

More docs can be found here: https://docs.github.com/en/repositories/working-with-files/managing-files/customizing-how-changed-files-appear-on-github

This is just something I noticed when I made the successor ml PR since that changed the grammar file and thus changed the generated grammar file too.
