### PR TITLE
Fix missing binding for `IntInf` patterns

### DIFF
--- a/compiler/FLINT/trans/translate.sml
+++ b/compiler/FLINT/trans/translate.sml
@@ -608,7 +608,7 @@ fun genintinfswitch (subject: lexp, cases, default) =
 	      (* end case *))
 	fun gen () =
 	      (case split (cases, [], [])
-		 of ([], largeints) => build largeints
+		 of ([], largeints) => LET (sv, subject, build largeints)
 		  | (smallints, largeints) =>
 		      let val iv = mkv ()
 		       in LET (sv, subject,


### PR DESCRIPTION
Patterns involving large integer literals are lowered to a chain of `IntInf` equality tests. The equality tests refer to a fresh variable that is never bound. This bug was likely introduced in the pattern-match compiler rewrite.

Fixes #352.