### PR TITLE
Make `build.sh` script more portable

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -66,7 +66,7 @@ while [ "$#" != "0" ] ; do
   case $arg in
     -help|-h) usage ;;
     -install)
-      if [[ $# -gt 0 ]] ; then
+      if [ "$#" -gt 0 ] ; then
         INSTALLDIR=$1; shift
       else
         usage
@@ -87,7 +87,7 @@ while [ "$#" != "0" ] ; do
       BUILD_LLVM_FLAGS="-sanitize-address $BUILD_LLVM_FLAGS"
       ;;
     -llvmdir)
-      if [[ $# -gt 0 ]] ; then
+      if [ "$#" -gt 0 ] ; then
         LLVMDIR_OPTION=$1; shift
       else
         usage


### PR DESCRIPTION
## Description
`[[` might not be supported by all shells. For example the script works fine on my macOS 26.5.2 but on my Debian 13.6 server it fails with the following error:
```
  ./build.sh: 69: [[: not found
```

## Related Issue
Homebrew PR: https://github.com/Homebrew/homebrew-core/pull/298924

## Motivation and Context
See "Description"

## How Has This Been Tested?
Tested on my Debian server and it works fine

