### PR TITLE
Create a lint workflow to catch shell script issues

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,6 @@
+version: 2
+updates:
+  - package-ecosystem: github-actions
+    directory: /
+    schedule:
+      interval: weekly

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -1,0 +1,31 @@
+name: lint
+
+on:
+  workflow_dispatch: ~
+  pull_request: ~
+  push:
+    branches:
+      - main
+
+permissions: {}
+
+concurrency:
+  group: lint-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  shellcheck:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          persist-credentials: false
+          submodules: false
+
+      - name: Report shellcheck warnings and errors
+        run: |
+          find -name '*.sh' -exec shellcheck -S warning {} +
+          shellcheck -S warning \
+            config/unpack \
+            package/macos/components/scripts/{copy-doc,preinstall,postinstall,postupgrade} \
+            tools/ml-lpt/{ml-ulex/ml-ulex,ml-antlr/ml-antlr}

--- a/.shellcheckrc
+++ b/.shellcheckrc
@@ -1,0 +1,8 @@
+# Allow x-prefixed comparisons
+disable=SC2268
+
+# Allow using `..` instead of $(..)
+disable=SC2006
+
+# The operators -ot/-nt/-ef are specified by POSIX.1-2024
+disable=SC3013

--- a/build.sh
+++ b/build.sh
@@ -17,14 +17,14 @@ here=$(pwd)
 #
 # set the SML root directory
 #
-cd $(dirname $cmd) || exit 1
+cd "$(dirname "$cmd")" || exit 1
 SMLNJ_ROOT=$(pwd)
 
 # default LLVM directory
 LLVM_DIRNAME=llvm21
 
 complain() {
-  echo "$cmd: !!! $@"
+  echo "$cmd: !!! $*"
   exit 1
 }
 
@@ -259,7 +259,7 @@ fish() {
       break
     fi
   done
-  if [ $ORIG_CM_DIR_ARC = unknown ] ; then
+  if [ "$ORIG_CM_DIR_ARC" = unknown ] ; then
     complain "Could not determine CM metadata directory name"
   else
     vsay "$cmd: CM metadata directory name is \"${ORIG_CM_DIR_ARC}\""
@@ -344,14 +344,12 @@ installdriver _arch-n-opsys .arch-n-opsys
 # run it to figure out what architecture and os we are using, define
 # corresponding variables...
 #
-ARCH_N_OPSYS=`"$BINDIR"/.arch-n-opsys`
-if [ "$?" != "0" ]; then
+if ! ARCH_N_OPSYS=`"$BINDIR"/.arch-n-opsys`; then
   complain "$BINDIR/.arch-n-opsys fails on this machine; please patch by hand and repeat the installation."
-  exit 2
 else
   vsay "$cmd: Script $BINDIR/.arch-n-opsys reports $ARCH_N_OPSYS."
 fi
-eval $ARCH_N_OPSYS
+eval "$ARCH_N_OPSYS"
 
 #
 # now install most of the other driver scripts
@@ -380,8 +378,7 @@ case $OPSYS in
     EXTRA_DEFS="AS_ACCEPTS_SDK=yes"
     ;;
   linux)
-    XDEFS=$("$CONFIGDIR/chk-global-names.sh")
-    if [ "$?" != "0" ]; then
+    if ! XDEFS=$("$CONFIGDIR/chk-global-names.sh"); then
       complain "Problems checking for underscores in asm names."
     fi
     ;;
@@ -390,26 +387,14 @@ esac
 # add other runtime-system options
 #
 if [ x"$SANITIZE_ADDRESS" = xyes ] ; then
-  if [ x"XDEFS" = x ] ; then
-    XDEFS="-fsanitize=address"
-  else
-    XDEFS="$XDEFS -fsanitize=address"
-  fi
-fi
-
-if [ x"XDEFS" != x ] ; then
-  if [ x"EXTRA_DEFS" = x ] ; then
-    EXTRA_DEFS="XDEFS=\"$XDEFS\""
-  else
-    EXTRA_DEFS="XDEFS=\"$XDEFS\" $EXTRA_DEFS"
-  fi
+  XDEFS="${XDEFS:+$XDEFS }-fsanitize=address"
 fi
 
 #
 # build the run-time system
 #
-if [ -x "$RUNDIR"/run.$ARCH-$OPSYS ]; then
-  vsay $cmd: Run-time system already exists.
+if [ -x "$RUNDIR/run.$ARCH-$OPSYS" ]; then
+  vsay "$cmd: Run-time system already exists."
 else
   #
   # first we configure and build the LLVM and CFGCodeGen libraries.  Note that
@@ -418,29 +403,31 @@ else
   #
   BUILD_LLVM_FLAGS="-install $INSTALLDIR $BUILD_LLVM_FLAGS"
   if [ x"$INSTALL_DEV" = xyes ] ; then
-    vsay $cmd: Building LLVM for all targets in $LLVMDIR
+    vsay "$cmd: Building LLVM for all targets in $LLVMDIR"
     cd "$LLVMDIR" || exit 1
-    dsay ./build-llvm.sh $BUILD_LLVM_FLAGS
+    dsay "./build-llvm.sh $BUILD_LLVM_FLAGS"
+    # shellcheck disable=SC2086
     ./build-llvm.sh $BUILD_LLVM_FLAGS || complain "Unable to build LLVM"
   elif [ ! -x "$BINDIR/llvm-config" ] ; then
-    vsay $cmd: Building LLVM in $LLVMDIR
+    vsay "$cmd: Building LLVM in $LLVMDIR"
     cd "$LLVMDIR" || exit 1
-    dsay ./build-llvm.sh $BUILD_LLVM_FLAGS
+    dsay "./build-llvm.sh $BUILD_LLVM_FLAGS"
+    # shellcheck disable=SC2086
     ./build-llvm.sh $BUILD_LLVM_FLAGS || complain "Unable to build LLVM"
   fi
   cd "$RUNTIMEDIR/objs" || exit 1
-  vsay $cmd: Compiling the run-time system.
-  make -f $RT_MAKEFILE $EXTRA_DEFS
-  if [ -x run.$ARCH-$OPSYS ]; then
-    mv run.$ARCH-$OPSYS "$RUNDIR"
-    if [ -f runx.$ARCH-$OPSYS ]; then
-      mv runx.$ARCH-$OPSYS "$RUNDIR"
+  vsay "$cmd: Compiling the run-time system."
+  make -f "$RT_MAKEFILE" $EXTRA_DEFS XDEFS="$XDEFS"
+  if [ -x "run.$ARCH-$OPSYS" ]; then
+    mv "run.$ARCH-$OPSYS" "$RUNDIR"
+    if [ -f "runx.$ARCH-$OPSYS" ]; then
+      mv "runx.$ARCH-$OPSYS" "$RUNDIR"
     fi
-    if [ -f runx.$ARCH-$OPSYS.so ]; then
-      mv runx.$ARCH-$OPSYS.so "$RUNDIR"
+    if [ -f "runx.$ARCH-$OPSYS.so" ]; then
+      mv "runx.$ARCH-$OPSYS.so" "$RUNDIR"
     fi
-    if [ -f runx.$ARCH-$OPSYS.a ]; then
-      mv runx.$ARCH-$OPSYS.a "$RUNDIR"
+    if [ -f "runx.$ARCH-$OPSYS.a" ]; then
+      mv "runx.$ARCH-$OPSYS.a" "$RUNDIR"
     fi
     make MAKE=make clean
   else
@@ -456,7 +443,7 @@ for f in llvm-libtool-darwin llvm-tblgen ; do
   rm -f bin/$f
 done
 
-vsay $cmd: runtime system built
+vsay "$cmd: runtime system built"
 if [ x"$ONLY_RUNTIME" = xyes ] ; then
   exit 1
 fi
@@ -472,7 +459,7 @@ BOOT_FILES=sml.boot.$ARCH-unix
 #
 # boot the base SML system
 #
-if [ -r "$HEAPDIR"/sml.$HEAP_SUFFIX ]; then
+if [ -r "$HEAPDIR/sml.$HEAP_SUFFIX" ]; then
   vsay "$cmd: Heap image $HEAPDIR/sml.$HEAP_SUFFIX already exists."
   fish "$LIBDIR"/smlnj/basis
   # ignore requested arc name since we have to live with what is there:
@@ -482,8 +469,8 @@ if [ -r "$HEAPDIR"/sml.$HEAP_SUFFIX ]; then
   vsay "$cmd: Re-creating a (customized) heap image..."
   "$BINDIR"/sml @CMredump "$SMLNJ_ROOT"/sml
   cd "$SMLNJ_ROOT" || exit 1
-  if [ -r sml.$HEAP_SUFFIX ]; then
-    mv sml.$HEAP_SUFFIX "$HEAPDIR"
+  if [ -r "sml.$HEAP_SUFFIX" ]; then
+    mv "sml.$HEAP_SUFFIX" "$HEAPDIR"
   else
     complain "Unable to re-create heap image (sml.$HEAP_SUFFIX)."
   fi
@@ -498,7 +485,7 @@ else
   export CM_DIR_ARC
   CM_DIR_ARC=${CM_DIR_ARC:-".cm"}
 
-  if [ $CM_DIR_ARC != $ORIG_CM_DIR_ARC ] ; then
+  if [ "$CM_DIR_ARC" != "$ORIG_CM_DIR_ARC" ]; then
     # now we have to make a symbolic link for each occurrence of
     # $ORIG_CM_DIR_ARC to $CM_DIR_ARC
     dirarcs "$ORIG_CM_DIR_ARC" "$CM_DIR_ARC" "$BOOT_FILES"
@@ -510,8 +497,8 @@ else
   dsay "$BINDIR"/.link-sml @SMLheap="$SMLNJ_ROOT"/sml @SMLboot=BOOTLIST @SMLalloc=$ALLOC
   if "$BINDIR"/.link-sml @SMLheap="$SMLNJ_ROOT"/sml @SMLboot=BOOTLIST @SMLalloc=$ALLOC ; then
     cd "$SMLNJ_ROOT" || exit 1
-    if [ -r sml.$HEAP_SUFFIX ]; then
-      mv sml.$HEAP_SUFFIX "$HEAPDIR"
+    if [ -r "sml.$HEAP_SUFFIX" ]; then
+      mv "sml.$HEAP_SUFFIX" "$HEAPDIR"
       cd "$BINDIR" || exit 1
       ln -s .run-sml sml
       #
@@ -520,10 +507,10 @@ else
       #
       cd "$SMLNJ_ROOT"/"$BOOT_FILES" || exit 1
       for anchor in * ; do
-        if [ -d $anchor ] ; then
+        if [ -d "$anchor" ] ; then
           dsay "move $anchor to $LIBDIR"
-          echo $anchor $anchor >> $CM_PATHCONFIG
-          move $anchor "$LIBDIR"/$anchor
+          echo "$anchor $anchor" >> "$CM_PATHCONFIG"
+          move "$anchor" "$LIBDIR/$anchor"
         fi
       done
       cd "$SMLNJ_ROOT" || exit 1
@@ -553,7 +540,7 @@ if [ x"$NOLIB" = xno ] ; then
   CM_TOLERATE_TOOL_FAILURES=true
   export CM_TOLERATE_TOOL_FAILURES
   if "$BINDIR"/sml -m \$smlnj/installer.cm ; then
-    vsay $cmd: Installation complete.
+    vsay "$cmd: Installation complete."
   else
     complain "Installation of libraries and programs failed."
   fi
@@ -582,7 +569,7 @@ if [ x"$MAKE_DOC" = xyes ] ; then
   ./configure
 
   if make doc && make distclean ; then
-    vsay $cmd: Documentation generation complete.
+    vsay "$cmd: Documentation generation complete."
   else
     complain "Error generating documentation."
   fi

--- a/compiler/CodeGen/asdl/gen.sh
+++ b/compiler/CodeGen/asdl/gen.sh
@@ -9,6 +9,8 @@
 # usage: gen.sh
 #
 
+set -eu
+
 cmd=gen.sh
 src=cfg.asdl
 

--- a/config/chk-global-names.sh
+++ b/config/chk-global-names.sh
@@ -6,27 +6,27 @@
 # Check to see if "_" is prepended to global names in the symbol table.
 #
 
+set -eu
+
 CC=${CC:-cc}
 
-TMP_FILE=/tmp/smlConfig-$$
+TMP_DIR=$(mktemp -d)
+
+trap 'rm -rf "$TMP_DIR"' EXIT
+
+TMP_FILE=$TMP_DIR/smlConfig
 TMP_FILE_C=$TMP_FILE.c
 
 WITNESS="w3E_4Ew3E_4Rrr_56TtT"
 
-cat > $TMP_FILE_C <<XXXX
+cat > "$TMP_FILE_C" <<XXXX
 void $WITNESS () {}
 XXXX
 
-$CC -c -o $TMP_FILE $TMP_FILE_C
-if [ "$?" != "0" ]; then
-    rm -f $TMP_FILE $TMP_FILE_C
-    exit 1
-fi
+$CC -c -o "$TMP_FILE" "$TMP_FILE_C"
 
-if `nm $TMP_FILE | grep -q "_$WITNESS"`
-  then echo "-DGLOBALS_HAVE_UNDERSCORE"
+if nm "$TMP_FILE" | grep -q "_$WITNESS"; then
+    echo "-DGLOBALS_HAVE_UNDERSCORE"
 fi
-
-rm -f $TMP_FILE $TMP_FILE_C
 
 exit 0

--- a/config/fetch.sh
+++ b/config/fetch.sh
@@ -8,12 +8,11 @@
 # NOTE: this script was extracted from the old "unpack" script and deals with
 # the fetching of files.
 
+set -e
+
 this="$0"
 ROOT="$1"
 shift
-
-LIBS="$ROOT"/libraries
-TOOLS="$ROOT"/tools
 
 CONFIGDIR="$ROOT/config"
 
@@ -23,9 +22,9 @@ VERSION=`cat "$CONFIGDIR"/version`
 SUFFIXES="tgz tar.gz tar.Z tz tar tar.bz2"
 
 vsay() {
-    if [ x${INSTALL_DEBUG} = xtrue ] ; then
+    if [ x"${INSTALL_DEBUG}" = xtrue ] ; then
 	echo "$@"
-    elif [ x${INSTALL_QUIETLY} = xtrue ] ; then
+    elif [ x"${INSTALL_QUIETLY}" = xtrue ] ; then
 	:
     else
 	echo "$@"
@@ -40,7 +39,7 @@ vsay() {
 #
 askurl() {
     echo "$this: Please, fetch $1 archive"
-    echo ' ('$2.'*' or $VERSION-$2.'*)'
+    echo " ($2.* or $VERSION-$2.*)"
     echo " from $3"
     echo " and then re-run this script!"
     exit 1
@@ -55,15 +54,15 @@ askurl() {
 #
 fetchurl() {
     getter=$1 ; shift
-    vsay $this: Fetching $1 from $3. Please stand by...
+    vsay "$this: Fetching $1 from $3. Please stand by..."
     fetched=no
     for base in "$2" "$VERSION-$2" ; do
 	for ext in $SUFFIXES ; do
 	    try=$base.$ext
-	    vsay $this: Trying $try ...
+	    vsay "$this: Trying $try ..."
 	    if "$getter" "$3"/"$try" "$ROOT"/"$try" ; then
 		fetched=yes
-		vsay $this: Fetching $try was a success.
+		vsay "$this: Fetching $try was a success."
 		break 2		# get out of both for-loops
 	    else
 		rm -f "$ROOT"/"$try"
@@ -71,8 +70,8 @@ fetchurl() {
 	done
     done
     if [ $fetched = no ] ; then
-	echo $this: Fetching $try was no success.
-	echo '  ' You should try to do it manually now.
+	echo "$this: Fetching $try was no success."
+	echo "   You should try to do it manually now."
 	askurl "$1" "$2" "$3"
     fi
 }
@@ -93,7 +92,7 @@ usecurl() {
 }
 
 testurlgetter() {
-    (exec >/dev/null 2>&1 ; exec $*)
+    (exec >/dev/null 2>&1 ; exec "$@")
 }
 
 #

--- a/config/unpack
+++ b/config/unpack
@@ -76,8 +76,8 @@ fetchurl() {
 	done
     done
     if [ $fetched = no ] ; then
-	echo $this: Fetching $try was no success.
-	echo '  ' You should try to do it manually now.
+	echo "$this: Fetching $try was no success."
+	echo "   You should try to do it manually now."
 	askurl "$1" "$2" "$3"
     fi
 }
@@ -98,7 +98,7 @@ usecurl() {
 }
 
 testurlgetter() {
-    (exec >/dev/null 2>&1 ; exec $*)
+    (exec >/dev/null 2>&1 ; exec "$@")
 }
 
 #
@@ -187,7 +187,7 @@ unarchive() {
 # no archive is found locally, it invokes $URLGETTER and tries again.
 # The variable $tryfetch is used to make sure this happens only once.
 fetch_n_unpack() {
-    cd "$2"
+    cd "$2" || exit 1
     if unarchive "$1" "$4".tgz un_tar_gz ||
        unarchive "$1" "$4".tar.gz un_tar_gz ||
        unarchive "$1" "$4".tar.Z un_tar_Z ||
@@ -195,7 +195,7 @@ fetch_n_unpack() {
        unarchive "$1" "$4".tar.bz2 un_tar_bz2 ||
        unarchive "$1" "$4".tz un_tar_Z
     then
-	: we are done
+	: "we are done"
     elif [ $tryfetch = yes ] ; then
 	urlgetter
 	$URLGETTER "$1" "$4" "$SRCARCHIVEURL"
@@ -232,7 +232,7 @@ do
 #         unpack run-time "$ROOT"/base runtime runtime
 # 	;;
       boot.*)
-        unpack bootfiles "$ROOT" sml.$i $i
+        unpack bootfiles "$ROOT" "sml.$i" "$i"
  	;;
       compiler)
 	unpack compiler "$ROOT" compiler compiler
@@ -303,9 +303,9 @@ do
         unpack "asdlgen tool and libraries" "$TOOLS" asdl asdl
         ;;
       *)
-	echo Unknown package: ${i}.
-	echo Trying default method...
-	unpack ${i} "$ROOT" ${i} ${i}
+	echo "Unknown package: ${i}."
+	echo "Trying default method..."
+	unpack "${i}" "$ROOT" "${i}" "${i}"
 	;;
     esac
 done

--- a/doc/src/smlnj-lib/src/scripts/gen-css.sh
+++ b/doc/src/smlnj-lib/src/scripts/gen-css.sh
@@ -13,7 +13,7 @@
 # general document colors
 #
 BACKGROUND="#fff"
-LIGHT_BACKGROUND="#f8f8f7"
+#LIGHT_BACKGROUND="#f8f8f7"
 MEDIUM_BACKGROUND="#ececec"
 #MEDIUM_BACKGROUND="#f8f8f7"
 #MEDIUM_BACKGROUND="#99ccff"
@@ -80,4 +80,4 @@ sed -e s/@BACKGROUND@/$BACKGROUND/g \
     -e s/@PUNCT_COLOR@/$PUNCT_COLOR/g \
     -e s/@TV_COLOR@/$TV_COLOR/g \
     -e s/@TY_COLOR@/$TY_COLOR/g \
-    $1
+    "$1"

--- a/doc/src/smlnj-lib/src/scripts/prepare-fun.sh
+++ b/doc/src/smlnj-lib/src/scripts/prepare-fun.sh
@@ -6,7 +6,9 @@
 # usage: scripts/prepare-fun.sh <dir> <fun>
 #
 
-function usage {
+set -eu
+
+usage() {
   echo "usage: scripts/prepare-str.sh <dir> <fun>"
   exit 1
 }
@@ -27,18 +29,18 @@ if [ ! -d "$d" ] ; then
   exit 1
 fi
 
-lib=$(basename $d/*-lib.adoc .adoc)
+lib=$(basename "$d"/*-lib.adoc .adoc)
 
 template=Templates/fun.adoc
 stem="fun-$name"
 mod_adoc="$d/$stem.adoc"
 
-if [ -f $mod_adoc ] ; then
+if [ -f "$mod_adoc" ] ; then
   echo "$0: file '$mod_adoc' already exists"
   exit 1
 fi
 
 ## create the placeholder for the module
-sed -e "s/@DIR@/$d/" -e "s/@LIBRARY@/$lib/" -e "s/@NAME@/$name/" $template > $mod_adoc
+sed -e "s/@DIR@/$d/" -e "s/@LIBRARY@/$lib/" -e "s/@NAME@/$name/" $template > "$mod_adoc"
 
 exit 0

--- a/doc/src/smlnj-lib/src/scripts/prepare-lib.sh
+++ b/doc/src/smlnj-lib/src/scripts/prepare-lib.sh
@@ -3,7 +3,9 @@
 # usage scripts/prepare-lib.sh <dir>
 #
 
-function usage {
+set -eu
+
+usage() {
   echo "usage: scripts/prepare-lib.sh <dir>"
   exit 1
 }
@@ -18,18 +20,18 @@ fi
 
 d=$1 ; shift
 
-if [ ! -f $d/MODULES ] ; then
+if [ ! -f "$d/MODULES" ]; then
   echo "missing $d/MODULES"
   exit 1
 fi
 
-lib=$(basename ../../$d/*-lib.cm .cm)
+lib=$(basename ../../"$d"/*-lib.cm .cm)
 lib_adoc=$d/$lib.adoc
 ## copy the header
-sed -e "s/@DIR@/$d/" -e "s/@LIBRARY@/$lib/" Templates/lib-head.adoc > $lib_adoc
+sed -e "s/@DIR@/$d/" -e "s/@LIBRARY@/$lib/" Templates/lib-head.adoc > "$lib_adoc"
 ## add module entries
 while read -r line ; do
-  name=$(echo $line | sed -e 's/structure //' -e 's/signature //' -e 's/functor //')
+  name=$(echo "$line" | sed -e 's/structure //' -e 's/signature //' -e 's/functor //')
   case $line in
     signature*)
       template=Templates/sig.adoc
@@ -50,34 +52,34 @@ while read -r line ; do
   mod_adoc="$d/$stem.adoc"
   link="xref:$stem.adoc"
   ## add the module to the library file
-  echo $link"[\`"$kw $name"\`]::" >> $lib_adoc
-  echo "  something" >> $lib_adoc
-  echo "" >> $lib_adoc
+  echo $link"[\`"$kw $name"\`]::" >> "$lib_adoc"
+  echo "  something" >> "$lib_adoc"
+  echo "" >> "$lib_adoc"
   ## create the placeholder for the module
-  sed -e "s/@DIR@/$d/" -e "s/@LIBRARY@/$lib/" -e "s/@NAME@/$name/" $template > $mod_adoc
-done < $d/MODULES
+  sed -e "s/@DIR@/$d/" -e "s/@LIBRARY@/$lib/" -e "s/@NAME@/$name/" "$template" > "$mod_adoc"
+done < "$d/MODULES"
 ## copy the middle part
-sed -e "s/@DIR@/$d/" -e "s/@LIBRARY@/$lib/" Templates/lib-mid.adoc >> $lib_adoc
+sed -e "s/@DIR@/$d/" -e "s/@LIBRARY@/$lib/" Templates/lib-mid.adoc >> "$lib_adoc"
 ## add the module entries for the PDF version
 while read -r line ; do
-  name=$(echo $line | sed -e 's/structure //' -e 's/signature //' -e 's/functor //')
+  name=$(echo "$line" | sed -e 's/structure //' -e 's/signature //' -e 's/functor //')
   case $line in
     signature*)
-      echo "include::sig-$name.adoc[]" >> $lib_adoc
-      echo "" >> $lib_adoc
+      echo "include::sig-$name.adoc[]" >> "$lib_adoc"
+      echo "" >> "$lib_adoc"
       ;;
     structure*)
-      echo "include::str-$name.adoc[]" >> $lib_adoc
-      echo "" >> $lib_adoc
+      echo "include::str-$name.adoc[]" >> "$lib_adoc"
+      echo "" >> "$lib_adoc"
       ;;
     functor*)
-      echo "include::fun-$name.adoc[]" >> $lib_adoc
-      echo "" >> $lib_adoc
+      echo "include::fun-$name.adoc[]" >> "$lib_adoc"
+      echo "" >> "$lib_adoc"
       ;;
   esac
-done < $d/MODULES
+done < "$d/MODULES"
 ## copy the footer
-sed -e "s/@DIR@/$d/" -e "s/@LIBRARY@/$lib/" Templates/lib-foot.adoc >> $lib_adoc
+sed -e "s/@DIR@/$d/" -e "s/@LIBRARY@/$lib/" Templates/lib-foot.adoc >> "$lib_adoc"
 
 
 exit 0

--- a/doc/src/smlnj-lib/src/scripts/prepare-sig.sh
+++ b/doc/src/smlnj-lib/src/scripts/prepare-sig.sh
@@ -6,7 +6,9 @@
 # usage: scripts/prepare-sig.sh <dir> <sign>
 #
 
-function usage {
+set -eu
+
+usage() {
   echo "usage: scripts/prepare-sig.sh <dir> <sign>"
   exit 1
 }
@@ -27,13 +29,13 @@ if [ ! -d "$d" ] ; then
   exit 1
 fi
 
-lib=$(basename $d/*-lib.adoc .adoc)
+lib=$(basename "$d"/*-lib.adoc .adoc)
 
 template=Templates/sig.adoc
 stem="sig-$name"
 mod_adoc="$d/$stem.adoc"
 
-if [ -f $mod_adoc ] ; then
+if [ -f "$mod_adoc" ] ; then
   echo "$0: file '$mod_adoc' already exists"
   exit 1
 fi
@@ -41,6 +43,6 @@ fi
 echo "creating $mod_adoc"
 
 ## create the placeholder for the module
-sed -e "s/@DIR@/$d/" -e "s/@LIBRARY@/$lib/" -e "s/@NAME@/$name/" $template > $mod_adoc
+sed -e "s/@DIR@/$d/" -e "s/@LIBRARY@/$lib/" -e "s/@NAME@/$name/" $template > "$mod_adoc"
 
 exit 0

--- a/doc/src/smlnj-lib/src/scripts/prepare-str.sh
+++ b/doc/src/smlnj-lib/src/scripts/prepare-str.sh
@@ -6,7 +6,7 @@
 # usage: scripts/prepare-str.sh <dir> <str>
 #
 
-function usage {
+usage() {
   echo "usage: scripts/prepare-str.sh <dir> <str>"
   exit 1
 }
@@ -27,18 +27,18 @@ if [ ! -d "$d" ] ; then
   exit 1
 fi
 
-lib=$(basename $d/*-lib.adoc .adoc)
+lib=$(basename "$d"/*-lib.adoc .adoc)
 
 template=Templates/str.adoc
 stem="str-$name"
 mod_adoc="$d/$stem.adoc"
 
-if [ -f $mod_adoc ] ; then
+if [ -f "$mod_adoc" ]; then
   echo "$0: file '$mod_adoc' already exists"
   exit 1
 fi
 
 ## create the placeholder for the module
-sed -e "s/@DIR@/$d/" -e "s/@LIBRARY@/$lib/" -e "s/@NAME@/$name/" $template > $mod_adoc
+sed -e "s/@DIR@/$d/" -e "s/@LIBRARY@/$lib/" -e "s/@NAME@/$name/" $template > "$mod_adoc"
 
 exit 0

--- a/package/macos/components/scripts/preinstall
+++ b/package/macos/components/scripts/preinstall
@@ -27,7 +27,7 @@ DST="$2"
 #
 if [ x"$DST" != x ] ; then
   if [ -d "$DST" ] ; then
-    rm -rf "$DST"/*
+    rm -rf "${DST:?}"/*
   fi
 else
   exit 1

--- a/package/unix/build-pkg.sh
+++ b/package/unix/build-pkg.sh
@@ -10,6 +10,8 @@
 # boot files needed to bootstrap the compiler.
 #
 
+set -e
+
 CMD="build-pkg.sh"
 GITHUB_URL="git@github.com:smlnj/smlnj.git"
 DISTROOT=smlnj
@@ -22,7 +24,7 @@ ROOT=$(pwd)
 
 cleanup () {
   if [ x"$CLEANUP" = xyes ] ; then
-    cd $ROOT
+    cd "$ROOT"
     rm -rf $DISTROOT
   fi
 }
@@ -34,18 +36,18 @@ usage() {
   echo "    -arch <arch>  -- specify architecture for boot files"
   echo "    -verbose      -- enable messages that document the packaging process"
   echo "    -no-clean     -- do not remove the source tree after packaging"
-  exit $1
+  exit "$1"
 }
 
 complain() {
-  echo "$CMD [Error]: $@"
+  echo "$CMD [Error]: $*"
   cleanup
   exit 1
 }
 
 vsay() {
   if [ x"$VERBOSE" = x-verbose ] ; then
-    echo "$CMD: $@"
+    echo "$CMD: $*"
   fi
 }
 
@@ -54,6 +56,7 @@ make_tarball() {
     Darwin) TARFLAGS="--no-mac-metadata $TARFLAGS" ;;
   esac
   vsay "tar $TARFLAGS -czf \"$1\" \"$2\""
+  # shellcheck disable=SC2086
   tar $TARFLAGS -czf "$1" "$2" || exit 1
 }
 
@@ -109,14 +112,13 @@ if [ x"$VERSION" != xnone ] ; then
   BRANCH="--branch v$VERSION"
 fi
 vsay "git clone --depth 1 --recurse-submodules $BRANCH $GITHUB_URL"
-git clone --depth 1 --recurse-submodules $BRANCH $GITHUB_URL
-if [ "$?" != 0 ] ; then
+if ! git clone --depth 1 --recurse-submodules $BRANCH $GITHUB_URL; then
   complain "unable to download source from GitHub"
 fi
 
 # switch to the cloned source directory
 #
-cd $DISTROOT
+cd "$DISTROOT"
 
 # remove stuff that we do not need
 #
@@ -149,7 +151,7 @@ fi
 
 # package up the source tree as a compressed tar file
 #
-cd $ROOT
-make_tarball smlnj-$ARCH-unix-$VERSION.tgz smlnj
+cd "$ROOT"
+make_tarball "smlnj-$ARCH-unix-$VERSION.tgz" smlnj
 
 cleanup

--- a/system/testml
+++ b/system/testml
@@ -11,9 +11,9 @@
 
 
 this=$0
-cmddir=`dirname $0`
-cmddir=`cd "$cmddir"; pwd`
-bindir=`cd "$cmddir/../bin"; pwd`
+cmddir=`dirname "$0"`
+cmddir=`cd "$cmddir" && pwd`
+bindir=`cd "$cmddir/../bin" && pwd`
 
 ARGS=""
 

--- a/tools/ml-lpt/ml-antlr/ml-antlr
+++ b/tools/ml-lpt/ml-antlr/ml-antlr
@@ -136,10 +136,10 @@ esac
 
 heap=${scripthome}ml-antlr.${ARCH}-${OPSYS}
 
-if test ! -r $heap ; then
+if test ! -r "$heap"; then
   echo "ml-antlr: no heap image!"
   exit 1
 fi
 
-exec sml @SMLload=$heap $@
+exec sml @SMLload="$heap" "$@"
 

--- a/tools/ml-lpt/ml-ulex/build.sh
+++ b/tools/ml-lpt/ml-ulex/build.sh
@@ -8,15 +8,15 @@
 #   -o image		-- specify the name of the heap image, "ml-ulex"
 #			   is the default.
 
+set -eu
+
 CMD=$0
 
 ROOT="ml-ulex"
 HEAP_IMAGE=""
 SMLNJROOT=`pwd`/../../..
 BIN=${INSTALLDIR:-$SMLNJROOT}/bin
-LIB=${INSTALLDIR:-$SMLNJROOT}/lib
 BUILD=$BIN/ml-build
-SML=$BIN/sml
 
 #
 # process command-line options
@@ -34,7 +34,7 @@ while [ "$#" != "0" ] ; do
       ;;
     -64) ;; # ignore size specification for compatibility with 2021.1
     *)
-      echo $CMD: invalid argument: $arg
+      echo "$CMD: invalid argument: $arg"
       exit 1
       ;;
   esac
@@ -46,6 +46,4 @@ fi
 
 #
 # Build the ml-ulex standalone program:
-"$BUILD" -DNO_ML_ANTLR -DNO_ML_LEX -DNO_ML_YACC sources.cm Main.main $HEAP_IMAGE
-
-exit 0
+"$BUILD" -DNO_ML_ANTLR -DNO_ML_LEX -DNO_ML_YACC sources.cm Main.main "$HEAP_IMAGE"

--- a/tools/ml-lpt/ml-ulex/ml-ulex
+++ b/tools/ml-lpt/ml-ulex/ml-ulex
@@ -15,10 +15,10 @@ case `uname -s` in
   *) heap=${scripthome}ml-ulex.x86-linux ;;
 esac
 
-if test ! -r $heap ; then
+if test ! -r "$heap" ; then
   echo "ml-ulex: no heap image!"
   exit 1
 fi
 
-exec sml @SMLload=$heap $@
+exec sml @SMLload="$heap" "$@"
 

--- a/tools/ml-yacc/build.sh
+++ b/tools/ml-yacc/build.sh
@@ -8,6 +8,8 @@
 #   -o image		-- specify the name of the heap image, "ml-yacc"
 #			   is the default.
 
+set -eu
+
 CMD=$0
 
 ROOT="ml-yacc"
@@ -32,7 +34,7 @@ while [ "$#" != "0" ] ; do
       ;;
     -64) ;; # ignore size specification for compatibility with 2021.1
     *)
-      echo $CMD: invalid argument: $arg
+      echo "$CMD: invalid argument: $arg"
       exit 1
       ;;
   esac
@@ -44,5 +46,3 @@ fi
 
 cd src
 "$BUILD" -DNO_ML_YACC -DNO_ML_LEX ml-yacc.cm ExportParseGen.parseGen "$HEAP_IMAGE"
-
-exit 0


### PR DESCRIPTION
This prevents issues like #361 for future releases
Add whatever branch is used for 2026.3/2027.1 development to the `push.branches` list to make sure it runs there.

## Description
Fixes a whole bunch of shell script incompatibilities, robustness issues, and bugs.
Adds a GitHub action to run this on PRs and pushes.

## Related Issue
General shell script incompatibilities

## Motivation and Context
This project has a ton of shell scripts with the `#!/bin/sh` shebang, but are only tested on a MacOS machine with zsh and Linux with bash.
A lot of these scripts have not been battle-tested either (ex. I've run into build issues when I was missing a directory, since the script didn't properly exit but instead kept running in the wrong directory).

I added a `.shellcheckrc` to ignore some shell writing styles that are used here but are generally frowned upon like using `` `..` `` instead of `$(..)`, but don't really matter for correctness nor robustness.

The `dependabot.yml` will get GitHub to automatically open PRs whenever the github action updates. I've used something similar personally and its very convenient.

## How Has This Been Tested?
I ran the workflow myself (example workflow [success](https://github.com/Skyb0rg007/smlnj/actions/runs/31894909600), example workflow [failure](https://github.com/Skyb0rg007/smlnj/actions/runs/31894708097)).
The scripts also work on my machine to build the project.

This particular action is extremely quick -- it took ~20 seconds between push and finish.

## Bug fix shortlist:

- `cd` not properly failing the script if it failed
- A `if [ x"DEFS" = x ]` line
- The SANITIZE_ADDRESS option didn't work (shell splitting doesn't respect quotes)
- chk-global-names.sh would `eval` the result of `grep` for no reason
- Shell functions would perform word-splitting when testing `curl`
- `ml-antlr` and `ml-ulex` wouldn't work when called on a path with spaces or `*`, since the shell scripts would re-split the arguments and perform globbing.
- chk-global-names.sh now creates a temporary directory using `mktemp -d` and creates files inside there. This improves the robustness of the script by allowing a `trap` to delete the directory instead of relying on checking the result of every command.

## Future work

It also caught that `system/testml` uses `$twoup` without defining it. I didn't try to fix that, but should be addressed.

This same kind of lint should also be run on [smlnj-llvm-21.1](https://github.com/smlnj/smlnj-llvm-21.1/ ).