### PR TITLE
Shellcheck workflow

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,6 @@
+version: 2
+updates:
+  - package-ecosystem: github-actions
+    directory: /
+    schedule:
+      interval: weekly

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -1,0 +1,31 @@
+name: lint
+
+on:
+  workflow_dispatch: ~
+  pull_request: ~
+  push:
+    branches:
+      - main
+
+permissions: {}
+
+concurrency:
+  group: lint-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  shellcheck:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          persist-credentials: false
+          submodules: false
+
+      - name: Report shellcheck warnings and errors
+        run: |
+          find -name '*.sh' -exec shellcheck -S warning {} +
+          shellcheck -S warning \
+            config/unpack \
+            package/macos/components/scripts/{copy-doc,preinstall,postinstall,postupgrade} \
+            tools/ml-lpt/{ml-ulex/ml-ulex,ml-antlr/ml-antlr}

--- a/.shellcheckrc
+++ b/.shellcheckrc
@@ -1,0 +1,8 @@
+# Allow x-prefixed comparisons
+disable=SC2268
+
+# Allow using `..` instead of $(..)
+disable=SC2006
+
+# The operators -ot/-nt/-ef are specified by POSIX.1-2024
+disable=SC3013


### PR DESCRIPTION
Add a GitHub action that runs shellcheck on the public script files. It only reports warnings + errors.

## Description
Extracted the .shellcheckrc, workflow, and dependabot.yml

## Motivation and Context
See #362

## How Has This Been Tested?
I ran this locally, and I know that the workflow fails because the fixes are not applied.
