### PR TITLE
Fix Word.countTrailingZeros

### DIFF
--- a/compiler/ElabData/prim/primop-bindings.sml
+++ b/compiler/ElabData/prim/primop-bindings.sml
@@ -161,7 +161,7 @@ structure PrimopBindings : sig
 	    mk("cnt_leading_ones", w_i, P.INLINE(InlP.CNTLO sz)) :-:
 	    mk("cnt_leading_zeros", w_i, P.INLINE(InlP.CNTLZ sz)) :-:
 	    mk("cnt_trailing_ones", w_i, P.INLINE(InlP.CNTTO sz)) :-:
-	    mk("cnt_trailing_zeros", w_i, P.INLINE(InlP.CNTLZ sz)) :-:
+	    mk("cnt_trailing_zeros", w_i, P.INLINE(InlP.CNTTZ sz)) :-:
             mk("is_pow2", w_b, P.PRIM(CP.IS_POW2 sz)) :-:
             mk("ceil_log2", ar(wty, BT.wordTy), P.INLINE(InlP.CEIL_LOG2 sz)) :-:
 	    shift("rotl", P.PURE{oper=PureP.ROTL, kind=nk}) :-:


### PR DESCRIPTION
Was previously bound to CNTLZ (cnt_leading_zeros).
