### PR TITLE
Fix position calculation of funsig token

### DIFF
--- a/compiler/Parse/lex/tokentable.sml
+++ b/compiler/Parse/lex/tokentable.sml
@@ -121,7 +121,7 @@ functor TokenTable (Tokens : SMLNJ_TOKENS) : sig
 	    ("fn"	, fn yypos => Tokens.FN(yypos,yypos+2)),
 	    ("fun"	, fn yypos => Tokens.FUN(yypos,yypos+3)),
 	    ("functor"	, fn yypos => Tokens.FUNCTOR(yypos,yypos+7)),
-	    ("funsig"	, fn yypos => Tokens.FUNSIG(yypos,yypos+7)),
+	    ("funsig"	, fn yypos => Tokens.FUNSIG(yypos,yypos+6)),
 	    ("handle"	, fn yypos => Tokens.HANDLE(yypos,yypos+6)),
 	    ("if"	, fn yypos => Tokens.IF(yypos,yypos+2)),
 	    ("in"	, fn yypos => Tokens.IN(yypos,yypos+2)),


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
The yypos was incorrectly modified when creating a FUNSIG token

