### PR TITLE
Fix the printing of vector patterns

### DIFF
--- a/compiler/Elaborator/matchcomp/generate.sml
+++ b/compiler/Elaborator/matchcomp/generate.sml
@@ -198,7 +198,7 @@ fun generate (decTree: MC.dectree, ruleMap: Preprocessing.ruleMap, allRules: rul
 					       if newvar (* vecmvar is a new mvar to be bound to vector *)
 					       then MU.bindPath (pathenv, path, vecmvar)
 					       else pathenv
-					in AS.SRULE (intCon n, NONE, genDecTree(decTree, pathenv))
+					in AS.SRULE (intCon n, NONE, genDecTree(decTree, newPathenv))
 				       end
 				   | genVCase _ = bug "genDecTree:genVCase: not a vector-length case"
 				 val switchCases = map genVCase cases


### PR DESCRIPTION
## Description
The correct pathenv was computed, but wasn't used.

## Related Issue
SML/NJ does not have a usable unused variable detector, which would have found this bug.

SML/NJ should implement my proposed extension + add an unused variable checker to prevent these issues:
https://github.com/SMLFamily/Successor-ML/issues/54

## Motivation and Context

I think this closes #142

## How Has This Been Tested?
Ran locally

