### PR TITLE
Fix the pattern match to reference REF dcon

### DIFF
--- a/compiler/FLINT/trans/pequal.sml
+++ b/compiler/FLINT/trans/pequal.sml
@@ -337,7 +337,7 @@ structure PEqual : PEQUAL =
 			      | expandRECdcon z = z
 			    in
 			      case map expandRECdcon dcons0
-			       of [{rep=REF,...}] => atomeq(tyc, ty)
+			       of [{rep=DA.REF,...}] => atomeq(tyc, ty)
 				| dcons => (
 				    find ty
 				      handle Notfound => let


### PR DESCRIPTION

## Description
The previous code used `REF`, which was treated like a pattern variable.

## Related Issue
SML/NJ does not have a usable unused variable detector, which would have found this bug.

SML/NJ should implement my proposed extension + add an unused variable checker to prevent these issues:
https://github.com/SMLFamily/Successor-ML/issues/54

## Motivation and Context
I think this closes #231 and #232

## How Has This Been Tested?
Ran locally.

## Note
This and the previous PRs were found this morning by asking the cheapest Claude code model to "find bugs in SML/NJ". It took about an hour to run and I've just been hand-verifying the bugs and fixes found from that. I imagine running such an analysis for longer and with a more powerful model would find additional bugs and their fixes.