### PR TITLE
Don't box Int64 during literal lifting

### DIFF
--- a/runtime/gc/build-literals.c
+++ b/runtime/gc/build-literals.c
@@ -637,9 +637,7 @@ ml_val_t BuildLiterals (ml_state_t *msp, Byte_t *code, int len)
 #ifdef DEBUG_LITERALS
 	    SayDebug("[%04d/%4d]: INT64(" PRINT ")\n", startPC, depth, arg.iArg);
 #endif
-	    res = ML_AllocWord64(msp, arg.iArg);
-	    PUSH (res);
-	    availSpace -= 2*WORD_SZB;
+	    PUSH ((ml_val_t)arg.iArg);
 	    break;
 #endif
 


### PR DESCRIPTION
The literal lifting transformation was converting records containing unboxed I64s into records containing boxed I64s, which the downstream function is not expecting. It would read the pointer as Int64.int and get the incorrect results as seen in the linked issue.

## Description
This fix was found by @zbyrn, but seems to only be possible on x86_64. This change fixed the bug on my machine for the specific reproducers.

## Related Issue
Fixes #394

## Motivation and Context
See related issue

## How Has This Been Tested?
This has not been tested, so it is marked as draft
