### PR TITLE
Fix Math.exp's argument reduction on negative arguments

### DIFF
--- a/doc/src/release-notes/2026.3-README.adoc
+++ b/doc/src/release-notes/2026.3-README.adoc
@@ -156,6 +156,8 @@ Here is a list of the issues and pull requests that are closed with this release
 | {issue-base}/454[`IntInf.pow` does not handle negative exponents correctly]
 | [.bugid]#456#
 | {issue-base}/456[`Timer.checkCPUTimer` double-counts garbage collector time]
+| [.bugid]#453#
+| {issue-base}/453[`Math.pow` is unusually inaccurate]
 // | [.bugid]#@ID@#
 // | {issue-base}/@ID@[@DESCRIPTION@]
 |=======

--- a/system/Basis/Implementation/Real/math64-common.sml
+++ b/system/Basis/Implementation/Real/math64-common.sml
@@ -205,7 +205,7 @@ structure Math64Common : sig
     fun exp (x:real) = let  (* propagates and generates inf's and nan's correctly *)
 	  fun exp_norm x = let
 	      (* argument reduction : x --> x - k*ln2 *)
-		val k = floor(invln2*x+copysign(half,x)) (* k=NINT(x/ln2) *)
+		val k = floor(invln2*x+half) (* k=NINT(x/ln2) *)
 		val K = real k
 	      (* express x-k*ln2 as z+c *)
 		val hi = x-K*ln2hi


### PR DESCRIPTION
The argument reduction is supposed to compute the equivalent of the C code `(int)(invln2 * x + copysign(0.5, x))`, which was translated to the SML `floor(invln2 * x + copysign(0.5, x))`. This is incorrect as C's cast rounds to 0 while floor rounds to negative infinity, so we should always be adding 0.5 to get the correct rounding.

## Description
The algorithm that was copied can be found in the OpenBSD source code:

https://github.com/openbsd/src/blob/e35ed435ad7c4fd83a1941d8923d9189948e7559/lib/libm/src/e_exp.c#L129

```c
const double invln2 = ...;
const double half[2] = {0.5,-0.5};
int32_t k, xsb;
/* ... */
xsb = (hx>>31)&1;		/* sign bit of x */
k  = invln2*x+halF[xsb];  /* note the implicit double->int32_t cast here, which *truncates* */
```

Another valid patch would be to replace `floor` with `trunc`, but then we would still need the `copysign`.

## Related Issue
Fixes #453

## How Has This Been Tested?
I ran tests locally

Using `floor` does result in different results from the BSD source code, but only for results which lie exactly between two floating point numbers, so it's just as accurate. If we want to replicate the BSD algorithm exactly then we'll need to add `trunc` as a primitive.

## Fun facts
This bug has existed in SML/NJ for over 30 years!
