### PR TITLE
Subtract gc time from nongc timer results

### DIFF
--- a/doc/src/release-notes/2026.3-README.adoc
+++ b/doc/src/release-notes/2026.3-README.adoc
@@ -154,6 +154,8 @@ Here is a list of the issues and pull requests that are closed with this release
 | {issue-base}/451[`Date.fromString` does not skip leading whitespace]
 | [.bugid]#454#
 | {issue-base}/454[`IntInf.pow` does not handle negative exponents correctly]
+| [.bugid]#456#
+| {issue-base}/456[`Timer.checkCPUTimer` double-counts garbage collector time]
 // | [.bugid]#@ID@#
 // | {issue-base}/@ID@[@DESCRIPTION@]
 |=======

--- a/system/Basis/Implementation/internal-timer.sml
+++ b/system/Basis/Implementation/internal-timer.sml
@@ -29,9 +29,10 @@ structure InternalTimer : sig
     in
     fun getTime () = let
 	  val (usr, sys, gc) = gettime' ()
+      val gcT = mkTime gc
 	  in {
-	    nongc = { usr = mkTime usr, sys = mkTime sys },
-	    gc    = { usr = mkTime gc, sys = Time.zeroTime }
+	    nongc = { usr = Time.-(mkTime usr, gcT), sys = mkTime sys },
+	    gc    = { usr = gcT, sys = Time.zeroTime }
 	  } end
     end (* local *)
 


### PR DESCRIPTION

## Description
Subtract the time spent in garbage collection from the `nongc` field when calculating elapsed time.
The `nongc` and `gc` fields are added back together in `checkCPUTimer`.

## Related Issue
Fixes #456

## Motivation and Context
Timer.checkCPUTimer was wrong

## How Has This Been Tested?
I'm waiting for LLVM to build right now, so not yet. I'll mark it as ready once that finishes.

